### PR TITLE
Naver Map Compose를 적용하고 메인 지도 화면을 표시한다

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    namespace = "com.example.testcompose2"
+    namespace = "com.example.android_kcs"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.example.testcompose2"
+        applicationId = "com.example.android_kcs"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,14 +10,14 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.TestCompose2"
+        android:theme="@style/Theme.Android_KCS"
         tools:targetApi="31">
         <activity
             tools:replace="android:theme, android:label"
             android:name="com.example.presentation.ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.TestCompose2">
+            android:theme="@style/Theme.Android_KCS">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.TestCompose2" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Android_KCS" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,9 @@ hilt = "2.47"
 timber = "5.0.1"
 compose-bom = "2023.08.00"
 
+naver-map-compose = "1.4"
+naver-map-location = "16.0.0"
+
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 androidx-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "runtime-ktx" }
@@ -53,6 +56,11 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+
+# Naver Maps
+#naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naver-map-compose"}
+#naver-map-compose = { group = "io.github.fornewid", name = "naver-map-location", version.ref = "naver-map-location"}
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,8 +22,10 @@ hilt = "2.47"
 timber = "5.0.1"
 compose-bom = "2023.08.00"
 
-naver-map-compose = "1.4"
+naver-map-compose = "1.3.3"
 naver-map-location = "16.0.0"
+naver-map-sdk = "3.16.1"
+play-services-location = "21.0.1"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -58,9 +60,10 @@ compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = 
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 
 # Naver Maps
-#naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naver-map-compose"}
-#naver-map-compose = { group = "io.github.fornewid", name = "naver-map-location", version.ref = "naver-map-location"}
-
+naver-map-sdk = "com.naver.maps:map-sdk:3.16.1"
+naver-map-compose = "io.github.fornewid:naver-map-compose:1.3.3"
+naver-map-location = "io.github.fornewid:naver-map-location:16.0.0"
+play-services-location = "com.google.android.gms:play-services-location:21.0.1"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin"}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -76,10 +76,9 @@ dependencies {
     debugImplementation(libs.compose.tooling)
     debugImplementation(libs.compose.test.manifest)
 
-    // naver map to compose
-    implementation("io.github.fornewid:naver-map-compose:1.3.3")
-    // naver map SDK
-    implementation("com.naver.maps:map-sdk:3.16.1")
-    implementation("com.google.android.gms:play-services-location:21.0.1")
-    implementation("io.github.fornewid:naver-map-location:16.0.0")
+    // naver map
+    api(libs.naver.map.compose)
+    api(libs.naver.map.sdk)
+    api(libs.naver.map.location)
+    api(libs.play.services.location)
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,8 +1,14 @@
+import java.util.Properties
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
 }
+
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
+val naverMapClientId: String = properties.getProperty("naverMapClientId")
 
 android {
     namespace = "com.example.presentation"
@@ -16,6 +22,8 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        manifestPlaceholders["naverMapClientId"] = naverMapClientId
     }
 
     buildTypes {
@@ -67,4 +75,11 @@ dependencies {
     androidTestImplementation(libs.compose.test.junit)
     debugImplementation(libs.compose.tooling)
     debugImplementation(libs.compose.test.manifest)
+
+    // naver map to compose
+    implementation("io.github.fornewid:naver-map-compose:1.3.3")
+    // naver map SDK
+    implementation("com.naver.maps:map-sdk:3.16.1")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+    implementation("io.github.fornewid:naver-map-location:16.0.0")
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
-            android:theme="@style/Theme.TestCompose2" />
+            android:theme="@style/Theme.Android_KCS" />
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"
             android:value="${naverMapClientId}" />

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity
@@ -8,6 +7,9 @@
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.TestCompose2" />
+        <meta-data
+            android:name="com.naver.maps.map.CLIENT_ID"
+            android:value="${naverMapClientId}" />
     </application>
 
 </manifest>

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -3,44 +3,44 @@ package com.example.presentation.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.presentation.ui.theme.TestCompose2Theme
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.NaverMap
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalNaverMapApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             TestCompose2Theme {
-                // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("Android")
+                    MainScreen()
                 }
             }
         }
     }
 }
 
+@ExperimentalNaverMapApi
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+fun MainScreen(modifier: Modifier = Modifier) {
+    Box(
         modifier = modifier
-    )
-}
+    ) {
+        NaverMap (
+            modifier = Modifier.fillMaxSize()
+        ) {
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TestCompose2Theme {
-        Greeting("Android")
+        }
     }
 }
+

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.example.presentation.ui.theme.TestCompose2Theme
+import com.example.presentation.ui.theme.Android_KCSTheme
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import com.naver.maps.map.compose.NaverMap
 
@@ -18,7 +18,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            TestCompose2Theme {
+            Android_KCSTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/presentation/src/main/java/com/example/presentation/ui/theme/Theme.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/theme/Theme.kt
@@ -38,7 +38,7 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun TestCompose2Theme(
+fun Android_KCSTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.TestCompose2" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Android_KCS" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven("https://naver.jfrog.io/artifactory/maven/")
     }
 }
 dependencyResolutionManagement {
@@ -10,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://naver.jfrog.io/artifactory/maven/")
     }
 }
 


### PR DESCRIPTION
## ⭐️ Issue Number 

- #3 
## 🚩 Summary
- Naver Map SDK 적용
- 메인 화면에 지도 적용
- app name에 맞춰서 이름 변경

<img width="300" alt="image" src="https://github.com/Korea-Certified-Store/AOS/assets/74500793/78b3e69b-4e9d-4ebd-80cb-9de28b06a8f4">

## 🛠️ Technical Concerns

### Naver Maps Client ID
Naver Maps의 Client ID는 타인에 노출되면 안되기 때문에 local.properties로 관리하였습니다.
이때 local.properties의 값을 manifest에서 사용하는 방법은 아래 블로그를 참고하였습니다.

참고: https://velog.io/@soyoung-dev/xbthvpob

### Naver Maps Compose의존성
Naver Maps Compose의 의존성은 [naver-map-compose](https://github.com/fornewid/naver-map-compose) 공식 Github을 참고하였습니다.
이때 gradle version catalog를 사용하면 `implementation`이 아니라 `api`를 사용해야 build가 되었습니다.

참고: https://github.com/fornewid/naver-map-compose/blob/main/naver-map-compose/build.gradle

## 🙂 To Reviwer
빌드시 Discord에 보낸 naverMapClientId를 local.properties에 추가해주세요!

## 📋 To Do

