### PR TITLE
전화 버튼을 누르면 전화 다이얼로그를 띄운다 (전화 걸기, 전화번호 저장, 클립보드에 복사)

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+
     <application>
         <activity
             android:name=".ui.MainActivity"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
 
     <application>
         <activity

--- a/presentation/src/main/java/com/example/presentation/model/Contact.kt
+++ b/presentation/src/main/java/com/example/presentation/model/Contact.kt
@@ -1,0 +1,7 @@
+package com.example.presentation.model
+
+data class Contact(
+    val name: String,
+    val phone: String,
+    val address: String
+)

--- a/presentation/src/main/java/com/example/presentation/model/StoreType.kt
+++ b/presentation/src/main/java/com/example/presentation/model/StoreType.kt
@@ -1,7 +1,10 @@
 package com.example.presentation.model
 
-enum class StoreType(val storeTypeName: String) {
-    KIND("착한 가격 업소"),
-    GREAT("모범 음식점"),
-    SAFE("안심 식당")
+import androidx.annotation.StringRes
+import com.example.presentation.R
+
+enum class StoreType(@StringRes val storeTypeName: Int) {
+    KIND(R.string.kind_price_store),
+    GREAT(R.string.great_store),
+    SAFE(R.string.safe_store)
 }

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -28,7 +28,11 @@ import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
 
 @Composable
-fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit, onClipboardCopied: (String) -> Unit) {
+fun StoreCallDialog(
+    storeNumber: String,
+    onCallDialogCanceled: (Boolean) -> Unit,
+    onClipboardCopied: (String) -> Unit
+) {
     Dialog(onDismissRequest = { onCallDialogCanceled(true) }) {
         Surface(
             modifier = Modifier
@@ -50,11 +54,11 @@ fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit, onClipboardCopied: 
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp
                 )
-                CallOptionTextButton(R.string.call_number, "0507-1369-4848")
-                CallOptionTextButton(R.string.save_number, "0507-1369-4848")
+                CallOptionTextButton(R.string.call_number, storeNumber)
+                CallOptionTextButton(R.string.save_number, storeNumber)
                 CallOptionTextButton(
                     R.string.copy_to_clipboard,
-                    "0507-1369-4848",
+                    storeNumber,
                     onClipboardCopied
                 )
                 CallCancelTextButton(onCallDialogCanceled = onCallDialogCanceled)

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -1,5 +1,6 @@
 package com.example.presentation.ui
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,7 +28,7 @@ import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
 
 @Composable
-fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit) {
+fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit, onClipboardCopied: (String) -> Unit) {
     Dialog(onDismissRequest = { onCallDialogCanceled(true) }) {
         Surface(
             modifier = Modifier
@@ -36,7 +37,10 @@ fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit) {
             shape = RoundedCornerShape(3.dp),
             color = White
         ) {
-            Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp), horizontalAlignment = Alignment.End) {
+            Column(
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
+                horizontalAlignment = Alignment.End
+            ) {
                 Text(
                     text = "0507-1369-4848",
                     modifier = Modifier
@@ -46,9 +50,13 @@ fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit) {
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp
                 )
-                CallOptionTextButton(stringResource(R.string.call_number))
-                CallOptionTextButton(stringResource(R.string.save_number))
-                CallOptionTextButton(stringResource(R.string.copy_to_clipboard))
+                CallOptionTextButton(R.string.call_number, "0507-1369-4848")
+                CallOptionTextButton(R.string.save_number, "0507-1369-4848")
+                CallOptionTextButton(
+                    R.string.copy_to_clipboard,
+                    "0507-1369-4848",
+                    onClipboardCopied
+                )
                 CallCancelTextButton(onCallDialogCanceled = onCallDialogCanceled)
             }
         }
@@ -56,16 +64,24 @@ fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit) {
 }
 
 @Composable
-fun CallOptionTextButton(description: String) {
+fun CallOptionTextButton(
+    @StringRes description: Int,
+    storeNumber: String,
+    onClipboardCopied: (String) -> Unit = {}
+) {
     TextButton(
-        onClick = {},
+        onClick = {
+            when (description) {
+                R.string.copy_to_clipboard -> onClipboardCopied(storeNumber)
+            }
+        },
         colors = ButtonDefaults.textButtonColors(contentColor = Black),
         shape = RectangleShape,
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(vertical = 15.dp, horizontal = 24.dp)
     ) {
         Text(
-            text = description,
+            text = stringResource(description),
             fontWeight = FontWeight.Medium,
             fontSize = 15.sp,
             textAlign = TextAlign.Start,

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -31,7 +31,8 @@ import com.example.presentation.ui.theme.White
 fun StoreCallDialog(
     storeNumber: String,
     onCallDialogCanceled: (Boolean) -> Unit,
-    onClipboardCopied: (String) -> Unit
+    onClipboardChanged: (String) -> Unit,
+    onCallStoreChanged: (String) -> Unit
 ) {
     Dialog(onDismissRequest = { onCallDialogCanceled(true) }) {
         Surface(
@@ -46,7 +47,7 @@ fun StoreCallDialog(
                 horizontalAlignment = Alignment.End
             ) {
                 Text(
-                    text = "0507-1369-4848",
+                    text = storeNumber,
                     modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentHeight()
@@ -54,12 +55,16 @@ fun StoreCallDialog(
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp
                 )
-                CallOptionTextButton(R.string.call_number, storeNumber)
-                CallOptionTextButton(R.string.save_number, storeNumber)
                 CallOptionTextButton(
-                    R.string.copy_to_clipboard,
-                    storeNumber,
-                    onClipboardCopied
+                    description = R.string.call_number,
+                    storeNumber = storeNumber,
+                    onCallStoreChanged = onCallStoreChanged
+                )
+                CallOptionTextButton(description = R.string.save_number, storeNumber = storeNumber)
+                CallOptionTextButton(
+                    description = R.string.copy_to_clipboard,
+                    storeNumber = storeNumber,
+                    onClipboardChanged = onClipboardChanged
                 )
                 CallCancelTextButton(onCallDialogCanceled = onCallDialogCanceled)
             }
@@ -71,12 +76,14 @@ fun StoreCallDialog(
 fun CallOptionTextButton(
     @StringRes description: Int,
     storeNumber: String,
-    onClipboardCopied: (String) -> Unit = {}
+    onClipboardChanged: (String) -> Unit = {},
+    onCallStoreChanged: (String) -> Unit = {}
 ) {
     TextButton(
         onClick = {
             when (description) {
-                R.string.copy_to_clipboard -> onClipboardCopied(storeNumber)
+                R.string.call_number -> onCallStoreChanged(storeNumber)
+                R.string.copy_to_clipboard -> onClipboardChanged(storeNumber)
             }
         },
         colors = ButtonDefaults.textButtonColors(contentColor = Black),

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -23,16 +23,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.example.presentation.R
+import com.example.presentation.model.Contact
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
 
 @Composable
 fun StoreCallDialog(
-    storeNumber: String,
+    contactInfo: Contact,
     onCallDialogCanceled: (Boolean) -> Unit,
+    onCallStoreChanged: (String) -> Unit,
+    onSaveStoreNumberChanged: (Contact) -> Unit,
     onClipboardChanged: (String) -> Unit,
-    onCallStoreChanged: (String) -> Unit
 ) {
     Dialog(onDismissRequest = { onCallDialogCanceled(true) }) {
         Surface(
@@ -47,7 +49,7 @@ fun StoreCallDialog(
                 horizontalAlignment = Alignment.End
             ) {
                 Text(
-                    text = storeNumber,
+                    text = contactInfo.phone,
                     modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentHeight()
@@ -57,13 +59,17 @@ fun StoreCallDialog(
                 )
                 CallOptionTextButton(
                     description = R.string.call_number,
-                    storeNumber = storeNumber,
+                    contactInfo = contactInfo,
                     onCallStoreChanged = onCallStoreChanged
                 )
-                CallOptionTextButton(description = R.string.save_number, storeNumber = storeNumber)
+                CallOptionTextButton(
+                    description = R.string.save_number,
+                    contactInfo = contactInfo,
+                    onSaveStoreNumberChanged = onSaveStoreNumberChanged
+                )
                 CallOptionTextButton(
                     description = R.string.copy_to_clipboard,
-                    storeNumber = storeNumber,
+                    contactInfo = contactInfo,
                     onClipboardChanged = onClipboardChanged
                 )
                 CallCancelTextButton(onCallDialogCanceled = onCallDialogCanceled)
@@ -75,15 +81,17 @@ fun StoreCallDialog(
 @Composable
 fun CallOptionTextButton(
     @StringRes description: Int,
-    storeNumber: String,
-    onClipboardChanged: (String) -> Unit = {},
-    onCallStoreChanged: (String) -> Unit = {}
+    contactInfo: Contact,
+    onCallStoreChanged: (String) -> Unit = {},
+    onSaveStoreNumberChanged: (Contact) -> Unit = {},
+    onClipboardChanged: (String) -> Unit = {}
 ) {
     TextButton(
         onClick = {
             when (description) {
-                R.string.call_number -> onCallStoreChanged(storeNumber)
-                R.string.copy_to_clipboard -> onClipboardChanged(storeNumber)
+                R.string.call_number -> onCallStoreChanged(contactInfo.phone)
+                R.string.save_number -> onSaveStoreNumberChanged(contactInfo)
+                R.string.copy_to_clipboard -> onClipboardChanged(contactInfo.phone)
             }
         },
         colors = ButtonDefaults.textButtonColors(contentColor = Black),

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -1,28 +1,34 @@
 package com.example.presentation.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.example.presentation.R
+import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
 
 @Composable
-@Preview
-fun StoreCallDialog() {
-    Dialog(onDismissRequest = {}) {
+fun StoreCallDialog(onCallDialogCanceled: (Boolean) -> Unit) {
+    Dialog(onDismissRequest = { onCallDialogCanceled(true) }) {
         Surface(
             modifier = Modifier
                 .width(282.dp)
@@ -30,50 +36,57 @@ fun StoreCallDialog() {
             shape = RoundedCornerShape(3.dp),
             color = White
         ) {
-            Column(modifier = Modifier.padding(horizontal = 44.dp, vertical = 14.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp), horizontalAlignment = Alignment.End) {
                 Text(
                     text = "0507-1369-4848",
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 15.dp),
+                        .wrapContentHeight()
+                        .padding(vertical = 15.dp, horizontal = 24.dp),
                     fontWeight = FontWeight.ExtraBold,
                     fontSize = 19.sp
                 )
-                Text(
-                    text = "전화 걸기",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 15.dp),
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 15.sp
-                    )
-                Text(
-                    text = "전화번호에 저장하기",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 15.dp),
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 15.sp
-                )
-                Text(
-                    text = "클립보드에 복사하기",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 15.dp),
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 15.sp
-                )
-                Text(
-                    text = "취소",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 15.dp),
-                    fontWeight = FontWeight.Medium,
-                    color = Blue,
-                    textAlign = TextAlign.End,
-                    fontSize = 12.sp
-                )
+                CallOptionTextButton(stringResource(R.string.call_number))
+                CallOptionTextButton(stringResource(R.string.save_number))
+                CallOptionTextButton(stringResource(R.string.copy_to_clipboard))
+                CallCancelTextButton(onCallDialogCanceled = onCallDialogCanceled)
             }
         }
+    }
+}
+
+@Composable
+fun CallOptionTextButton(description: String) {
+    TextButton(
+        onClick = {},
+        colors = ButtonDefaults.textButtonColors(contentColor = Black),
+        shape = RectangleShape,
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(vertical = 15.dp, horizontal = 24.dp)
+    ) {
+        Text(
+            text = description,
+            fontWeight = FontWeight.Medium,
+            fontSize = 15.sp,
+            textAlign = TextAlign.Start,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+fun CallCancelTextButton(onCallDialogCanceled: (Boolean) -> Unit) {
+    TextButton(
+        onClick = { onCallDialogCanceled(true) },
+        colors = ButtonDefaults.textButtonColors(contentColor = Blue),
+        shape = RectangleShape,
+        modifier = Modifier,
+        contentPadding = PaddingValues(horizontal = 10.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.cancel),
+            fontWeight = FontWeight.Medium,
+            fontSize = 12.sp
+        )
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/CallScreen.kt
@@ -1,0 +1,79 @@
+package com.example.presentation.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.example.presentation.ui.theme.Blue
+import com.example.presentation.ui.theme.White
+
+@Composable
+@Preview
+fun StoreCallDialog() {
+    Dialog(onDismissRequest = {}) {
+        Surface(
+            modifier = Modifier
+                .width(282.dp)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(3.dp),
+            color = White
+        ) {
+            Column(modifier = Modifier.padding(horizontal = 44.dp, vertical = 14.dp)) {
+                Text(
+                    text = "0507-1369-4848",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 15.dp),
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 19.sp
+                )
+                Text(
+                    text = "전화 걸기",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 15.dp),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 15.sp
+                    )
+                Text(
+                    text = "전화번호에 저장하기",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 15.dp),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 15.sp
+                )
+                Text(
+                    text = "클립보드에 복사하기",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 15.dp),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 15.sp
+                )
+                Text(
+                    text = "취소",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 15.dp),
+                    fontWeight = FontWeight.Medium,
+                    color = Blue,
+                    textAlign = TextAlign.End,
+                    fontSize = 12.sp
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -1,9 +1,15 @@
 package com.example.presentation.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.example.presentation.R
 import com.example.presentation.ui.theme.Android_KCSTheme
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 
@@ -13,9 +19,26 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            val (isClipboardClicked, onClipboardCopied) = remember { mutableStateOf("") }
+
             Android_KCSTheme {
-                MainScreen()
+                MainScreen(onClipboardCopied)
             }
+
+            if (isClipboardClicked.isNotEmpty()) {
+                copyToClipboard(isClipboardClicked)
+            }
+        }
+    }
+
+    private fun copyToClipboard(text: String) {
+        val clipboard: ClipboardManager = this.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText(getString(R.string.store_number), text)
+        clipboard.setPrimaryClip(clip)
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S) {
+            Toast.makeText(this,
+                getString(R.string.copy_to_clipboard_description), Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -6,15 +6,16 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.ContactsContract
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import com.example.presentation.R
+import com.example.presentation.model.Contact
 import com.example.presentation.ui.theme.Android_KCSTheme
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
-
 
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalNaverMapApi::class)
@@ -22,23 +23,54 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val (clipboardStoreNumber, onClipboardChanged) = remember { mutableStateOf("") }
             val (callStoreNumber, onCallStoreChanged) = remember { mutableStateOf("") }
+            val (contactInfo, onSaveStoreNumberChanged) = remember {
+                mutableStateOf(INIT_CONTACT_INFO)
+            }
+            val (clipboardStoreNumber, onClipboardChanged) = remember { mutableStateOf("") }
 
             Android_KCSTheme {
-                MainScreen(onClipboardChanged, onCallStoreChanged)
-            }
-
-            if (clipboardStoreNumber.isNotEmpty()) {
-                copyToClipboard(clipboardStoreNumber)
-                onClipboardChanged("")
+                MainScreen(onCallStoreChanged, onSaveStoreNumberChanged, onClipboardChanged)
             }
 
             if (callStoreNumber.isNotEmpty()) {
                 callStore(callStoreNumber)
                 onCallStoreChanged("")
             }
+
+            if (contactInfo.name.isNotEmpty()) {
+                saveStoreNumber(contactInfo)
+                onSaveStoreNumberChanged(INIT_CONTACT_INFO)
+            }
+
+            if (clipboardStoreNumber.isNotEmpty()) {
+                copyToClipboard(clipboardStoreNumber)
+                onClipboardChanged("")
+            }
         }
+    }
+
+    private fun callStore(storeNumber: String) {
+        startActivity(
+            Intent(
+                "android.intent.action.DIAL",
+                Uri.parse(String.format(resources.getString(R.string.tel), storeNumber))
+            )
+        )
+    }
+
+    private fun saveStoreNumber(contactInfo: Contact) {
+        val intent = Intent(ContactsContract.Intents.Insert.ACTION).apply {
+            type = ContactsContract.RawContacts.CONTENT_TYPE
+        }
+
+        intent.apply {
+            putExtra(ContactsContract.Intents.Insert.NAME, contactInfo.name)
+            putExtra(ContactsContract.Intents.Insert.PHONE, contactInfo.phone)
+            putExtra(ContactsContract.Intents.Insert.POSTAL, contactInfo.address)
+        }
+
+        startActivity(intent)
     }
 
     private fun copyToClipboard(text: String) {
@@ -55,12 +87,7 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun callStore(storeNumber: String) {
-        startActivity(
-            Intent(
-                "android.intent.action.DIAL",
-                Uri.parse(String.format(resources.getString(R.string.tel), storeNumber))
-            )
-        )
+    companion object {
+        val INIT_CONTACT_INFO = Contact("", "", "")
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -79,7 +79,7 @@ class MainActivity : ComponentActivity() {
         val clip = ClipData.newPlainText(getString(R.string.store_number), text)
         clipboard.setPrimaryClip(clip)
 
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
             Toast.makeText(
                 this,
                 getString(R.string.copy_to_clipboard_description), Toast.LENGTH_SHORT

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -2,6 +2,8 @@ package com.example.presentation.ui
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
@@ -13,32 +15,52 @@ import com.example.presentation.R
 import com.example.presentation.ui.theme.Android_KCSTheme
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 
+
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalNaverMapApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val (isClipboardClicked, onClipboardCopied) = remember { mutableStateOf("") }
+            val (clipboardStoreNumber, onClipboardChanged) = remember { mutableStateOf("") }
+            val (callStoreNumber, onCallStoreChanged) = remember { mutableStateOf("") }
 
             Android_KCSTheme {
-                MainScreen(onClipboardCopied)
+                MainScreen(onClipboardChanged, onCallStoreChanged)
             }
 
-            if (isClipboardClicked.isNotEmpty()) {
-                copyToClipboard(isClipboardClicked)
+            if (clipboardStoreNumber.isNotEmpty()) {
+                copyToClipboard(clipboardStoreNumber)
+                onClipboardChanged("")
+            }
+
+            if (callStoreNumber.isNotEmpty()) {
+                callStore(callStoreNumber)
+                onCallStoreChanged("")
             }
         }
     }
 
     private fun copyToClipboard(text: String) {
-        val clipboard: ClipboardManager = this.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        val clipboard: ClipboardManager =
+            this.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
         val clip = ClipData.newPlainText(getString(R.string.store_number), text)
         clipboard.setPrimaryClip(clip)
 
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S) {
-            Toast.makeText(this,
-                getString(R.string.copy_to_clipboard_description), Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this,
+                getString(R.string.copy_to_clipboard_description), Toast.LENGTH_SHORT
+            ).show()
         }
+    }
+
+    private fun callStore(storeNumber: String) {
+        startActivity(
+            Intent(
+                "android.intent.action.DIAL",
+                Uri.parse(String.format(resources.getString(R.string.tel), storeNumber))
+            )
+        )
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.Color.Companion.LightGray
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -453,7 +454,7 @@ private fun Chip(
         shape = RoundedCornerShape(20.dp)
     ) {
         Text(
-            text = storeType.storeTypeName,
+            text = stringResource(storeType.storeTypeName),
             color = MediumGray,
             fontSize = 9.sp,
             modifier = Modifier.padding(horizontal = 7.dp, vertical = 4.dp)

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -136,6 +136,7 @@ fun MainScreen() {
     }
 
     val (isCallClicked, onCallDialogChanged) = remember { mutableStateOf(false) }
+    val (isCallDialogCancelClicked, onCallDialogCanceled) = remember { mutableStateOf(false) }
 
     InitMap(
         isMarkerClicked,
@@ -150,9 +151,15 @@ fun MainScreen() {
         onCallDialogChanged
     )
 
-    if (isCallClicked) {
-        StoreCallDialog()
+    if (isCallClicked && isCallDialogCancelClicked.not()) {
+        StoreCallDialog(onCallDialogCanceled)
     }
+
+    if (isCallDialogCancelClicked) {
+        onCallDialogCanceled(false)
+        onCallDialogChanged(false)
+    }
+
 }
 
 @ExperimentalNaverMapApi

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -75,7 +75,7 @@ import com.naver.maps.map.overlay.OverlayImage
 
 @ExperimentalNaverMapApi
 @Composable
-fun MainScreen() {
+fun MainScreen(onClipboardCopied: (String) -> Unit) {
     val testMarkerData = listOf(
         StoreInfo(
             storeId = 1,
@@ -153,7 +153,7 @@ fun MainScreen() {
     )
 
     if (isCallClicked && isCallDialogCancelClicked.not()) {
-        StoreCallDialog(onCallDialogCanceled)
+        StoreCallDialog(onCallDialogCanceled, onClipboardCopied)
     }
 
     if (isCallDialogCancelClicked) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -73,7 +73,7 @@ import com.naver.maps.map.overlay.OverlayImage
 
 @ExperimentalNaverMapApi
 @Composable
-fun MainScreen(onClipboardCopied: (String) -> Unit) {
+fun MainScreen(onClipboardChanged: (String) -> Unit, onCallStoreChanged: (String) -> Unit) {
     val testMarkerData = listOf(
         StoreInfo(
             storeId = 1,
@@ -83,7 +83,7 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
             formattedAddress = "주소",
             regularOpeningHours = "11:00 ~ 23:00",
             location = Coordinate(37.5657, 126.9775),
-            internationalPhoneNumber = "연락처",
+            internationalPhoneNumber = "1234",
             storeCertificationId = listOf(StoreType.KIND)
         ),
         StoreInfo(
@@ -94,7 +94,7 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
             formattedAddress = "주소",
             regularOpeningHours = "11:00 ~ 23:00",
             location = Coordinate(37.5667, 126.9785),
-            internationalPhoneNumber = "연락처",
+            internationalPhoneNumber = "+82 2-1234-5678",
             storeCertificationId = listOf(StoreType.GREAT, StoreType.KIND)
         ),
         StoreInfo(
@@ -105,7 +105,7 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
             formattedAddress = "주소",
             regularOpeningHours = "11:00 ~ 23:00",
             location = Coordinate(37.5647, 126.9770),
-            internationalPhoneNumber = "연락처",
+            internationalPhoneNumber = "+82 2-1234-5678",
             storeCertificationId = listOf(StoreType.SAFE, StoreType.GREAT, StoreType.KIND)
         )
     )
@@ -148,7 +148,8 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
         StoreCallDialog(
             clickedStoreInfo.internationalPhoneNumber,
             onCallDialogCanceled,
-            onClipboardCopied
+            onClipboardChanged,
+            onCallStoreChanged
         )
     }
 

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -145,7 +145,11 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
     )
 
     if (isCallClicked && isCallDialogCancelClicked.not()) {
-        StoreCallDialog(onCallDialogCanceled, onClipboardCopied)
+        StoreCallDialog(
+            clickedStoreInfo.internationalPhoneNumber,
+            onCallDialogCanceled,
+            onClipboardCopied
+        )
     }
 
     if (isCallDialogCancelClicked) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -135,6 +135,8 @@ fun MainScreen() {
         isMarkerClicked = value
     }
 
+    val (isCallClicked, onCallDialogChanged) = remember { mutableStateOf(false) }
+
     InitMap(
         isMarkerClicked,
         onBottomSheetChanged,
@@ -144,8 +146,13 @@ fun MainScreen() {
     )
     StoreSummaryBottomSheet(
         if (isMarkerClicked) BOTTOM_SHEET_HEIGHT_ON else BOTTOM_SHEET_HEIGHT_OFF,
-        clickedStoreInfo
+        clickedStoreInfo,
+        onCallDialogChanged
     )
+
+    if (isCallClicked) {
+        StoreCallDialog()
+    }
 }
 
 @ExperimentalNaverMapApi
@@ -294,11 +301,15 @@ fun ClickedStoreMarker(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun StoreSummaryBottomSheet(heightType: Int, clickedStoreInfo: StoreInfo) {
+fun StoreSummaryBottomSheet(
+    heightType: Int,
+    clickedStoreInfo: StoreInfo,
+    onCallDialogChanged: (Boolean) -> Unit
+) {
     BottomSheetScaffold(
         sheetContent = {
             Column {
-                StoreSummaryInfo(clickedStoreInfo)
+                StoreSummaryInfo(clickedStoreInfo, onCallDialogChanged)
             }
         },
         sheetPeekHeight = heightType.dp,
@@ -323,7 +334,8 @@ fun StoreSummaryBottomSheet(heightType: Int, clickedStoreInfo: StoreInfo) {
 
 @Composable
 fun StoreSummaryInfo(
-    storeInfo: StoreInfo
+    storeInfo: StoreInfo,
+    onCallDialogChanged: (Boolean) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -371,7 +383,7 @@ fun StoreSummaryInfo(
                 )
             }
             Spacer(modifier = Modifier.height(13.dp))
-            StoreCallButton()
+            StoreCallButton(onCallDialogChanged)
             Spacer(modifier = Modifier.height(14.dp))
         }
         Column {
@@ -381,11 +393,12 @@ fun StoreSummaryInfo(
     }
 }
 
-@Preview
 @Composable
-fun StoreCallButton() {
+fun StoreCallButton(onCallDialogChanged: (Boolean) -> Unit) {
     Button(
-        onClick = {},
+        onClick = {
+            onCallDialogChanged(true)
+        },
         modifier = Modifier
             .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
         contentPadding = PaddingValues(horizontal = 27.dp, vertical = 6.dp),

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.presentation.R
+import com.example.presentation.model.Contact
 import com.example.presentation.model.Coordinate
 import com.example.presentation.model.StoreInfo
 import com.example.presentation.model.StoreType
@@ -73,7 +74,11 @@ import com.naver.maps.map.overlay.OverlayImage
 
 @ExperimentalNaverMapApi
 @Composable
-fun MainScreen(onClipboardChanged: (String) -> Unit, onCallStoreChanged: (String) -> Unit) {
+fun MainScreen(
+    onCallStoreChanged: (String) -> Unit,
+    onSaveStoreNumberChanged: (Contact) -> Unit,
+    onClipboardChanged: (String) -> Unit,
+) {
     val testMarkerData = listOf(
         StoreInfo(
             storeId = 1,
@@ -146,10 +151,15 @@ fun MainScreen(onClipboardChanged: (String) -> Unit, onCallStoreChanged: (String
 
     if (isCallClicked && isCallDialogCancelClicked.not()) {
         StoreCallDialog(
-            clickedStoreInfo.internationalPhoneNumber,
+            Contact(
+                clickedStoreInfo.displayName,
+                clickedStoreInfo.internationalPhoneNumber,
+                clickedStoreInfo.formattedAddress
+            ),
             onCallDialogCanceled,
-            onClipboardChanged,
-            onCallStoreChanged
+            onCallStoreChanged,
+            onSaveStoreNumberChanged,
+            onClipboardChanged
         )
     }
 

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -29,10 +29,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -112,7 +110,7 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
         )
     )
 
-    var clickedStoreInfo by remember {
+    val (clickedStoreInfo, onStoreInfoChanged) = remember {
         mutableStateOf(
             StoreInfo(
                 storeId = 0,
@@ -127,14 +125,8 @@ fun MainScreen(onClipboardCopied: (String) -> Unit) {
             )
         )
     }
-    val onStoreInfoChanged = { value: StoreInfo ->
-        clickedStoreInfo = value
-    }
 
-    var isMarkerClicked by remember { mutableStateOf(false) }
-    val onBottomSheetChanged = { value: Boolean ->
-        isMarkerClicked = value
-    }
+    val (isMarkerClicked, onBottomSheetChanged) = remember { mutableStateOf(false) }
 
     val (isCallClicked, onCallDialogChanged) = remember { mutableStateOf(false) }
     val (isCallDialogCancelClicked, onCallDialogCanceled) = remember { mutableStateOf(false) }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="title_activity_main">MainActivity</string>
+    <string name="cancel">취소</string>
+    <string name="call_number">전화 걸기</string>
+    <string name="save_number">전화번호에 저장하기</string>
+    <string name="copy_to_clipboard">클립보드에 복사하기</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="safe_store">안심 식당</string>
     <string name="store_number">store_number</string>
     <string name="copy_to_clipboard_description">클립보드에 복사되었습니다.</string>
+    <string name="tel">tel:%s</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="kind_price_store">착한 가격 업소</string>
     <string name="great_store">모범 음식점</string>
     <string name="safe_store">안심 식당</string>
+    <string name="store_number">store_number</string>
+    <string name="copy_to_clipboard_description">클립보드에 복사되었습니다.</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="call_number">전화 걸기</string>
     <string name="save_number">전화번호에 저장하기</string>
     <string name="copy_to_clipboard">클립보드에 복사하기</string>
+    <string name="kind_price_store">착한 가격 업소</string>
+    <string name="great_store">모범 음식점</string>
+    <string name="safe_store">안심 식당</string>
 </resources>


### PR DESCRIPTION
## ⭐️ Issue Number

- #10 

## 🚩 Summary
- 전화 다이얼로그 구현
- 전화 걸기 구현
- 전화번호 저장 구현
- 전화번호 클립보드 복사 구현

https://github.com/Korea-Certified-Store/AOS/assets/74500793/929a4ba0-253a-4a43-850b-a371392228fd

## 🛠️ Technical Concerns

### 클립보드 복사할 때 피드백 제공
사용자는 앱이 콘텐츠를 클립보드에 복사할 때 시각적 피드백을 기대합니다. 이 작업은 Android 13 이상 사용자의 경우 자동으로 수행되지만 이전 버전에서는 수동으로 구현해야 합니다.
따라서 Android 13 미만에서 복사의 성공을 알리기 위해 따로 예외처리를 진행해주었습니다.
```kotlin
if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
  Toast.makeText(
    this,
    getString(R.string.copy_to_clipboard_description), Toast.LENGTH_SHORT
  ).show()
}
```
[참고](https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#Feedback)

## 🙂 To Reviwer
- CallScreen으로 전화 다이얼로그를 따로 파일로 빼주었습니다. MainScreen 파일에 다 두는 것 보다 훨씬 깔끔한 것 같아서 추후에 BottomSheet도 개인 파일로 빼겠습니다!
- StoreCallDialog에서 재활용을 위해 CallOptionTextButton() 함수를 만들어 주었고, textButton의 경우 코드양이 많아 재활용되지는 않지만 CallCancelTextButton() 함수를 만들어주었습니다. 따로 함수로 빼니 훨씬 코드를 이해하는데 도움이 되었습니다. 재활용되지 않더라도 이렇게 다 함수로 빼는게 좋을까요??

## 📋 To Do
- [ ] 전화번호에 +82 붙는데, 이 상태로도 제대로 전화 걸리는지 확인하기
