### PR TITLE
 가게 리스트를 담은 BottomSheet를 보여준다

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -18,6 +18,7 @@ import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.map.NaverMapScreen
 import com.example.presentation.ui.map.call.StoreCallDialog
 import com.example.presentation.ui.map.filter.FilterComponent
+import com.example.presentation.ui.map.list.StoreListBottomSheet
 import com.example.presentation.ui.map.reload.ReloadButton
 import com.example.presentation.ui.map.summary.DimScreen
 import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
@@ -176,6 +177,8 @@ fun MainScreen(
     if (bottomSheetExpandedType == ExpandedType.FULL || bottomSheetExpandedType == ExpandedType.HALF || bottomSheetExpandedType == ExpandedType.DIM_CLICK) {
         DimScreen(bottomSheetExpandedType, onBottomSheetExpandedChanged)
     }
+
+    StoreListBottomSheet()
 
     if (isMarkerClicked) {
         StoreSummaryBottomSheet(

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -188,7 +188,13 @@ fun MainScreen(
             onBottomSheetExpandedChanged
         )
     } else {
-        StoreListBottomSheet(bottomSheetExpandedType, onBottomSheetExpandedChanged)
+        StoreListBottomSheet(
+            bottomSheetExpandedType,
+            onBottomSheetExpandedChanged,
+            onBottomSheetChanged,
+            onStoreInfoChanged,
+            onMarkerChanged
+        )
     }
 
     if (isSplashScreenShowAble) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -178,8 +178,6 @@ fun MainScreen(
         DimScreen(bottomSheetExpandedType, onBottomSheetExpandedChanged)
     }
 
-    StoreListBottomSheet()
-
     if (isMarkerClicked) {
         StoreSummaryBottomSheet(
             clickedStoreInfo,
@@ -189,6 +187,8 @@ fun MainScreen(
             bottomSheetExpandedType,
             onBottomSheetExpandedChanged
         )
+    } else {
+        StoreListBottomSheet(bottomSheetExpandedType, onBottomSheetExpandedChanged)
     }
 
     if (isSplashScreenShowAble) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -127,6 +127,8 @@ fun MainScreen(
 
     val (errorSnackBarMsg, onErrorSnackBarChanged) = remember { mutableStateOf("") }
 
+    val (isListItemClicked, onListItemChanged) = remember { mutableStateOf(false) }
+
     NaverMapScreen(
         mapViewModel,
         isMarkerClicked,
@@ -149,7 +151,10 @@ fun MainScreen(
         onCurrentMapChanged,
         isFilteredMarker,
         onFilteredMarkerChanged,
-        onErrorSnackBarChanged
+        onErrorSnackBarChanged,
+        isListItemClicked,
+        onListItemChanged,
+        clickedStoreInfo.location
     )
 
     if (isMapGestured) {
@@ -193,7 +198,8 @@ fun MainScreen(
             onBottomSheetExpandedChanged,
             onBottomSheetChanged,
             onStoreInfoChanged,
-            onMarkerChanged
+            onMarkerChanged,
+            onListItemChanged
         )
     }
 

--- a/presentation/src/main/java/com/example/presentation/ui/component/BottomSheetHandleComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/component/BottomSheetHandleComponent.kt
@@ -1,0 +1,26 @@
+package com.example.presentation.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.presentation.ui.theme.SemiLightGray
+
+@Composable
+fun BottomSheetDragHandle() {
+    Column {
+        Spacer(modifier = Modifier.height(10.dp))
+        Box(
+            modifier = Modifier
+                .width(34.dp)
+                .height(4.dp)
+                .background(SemiLightGray, shape = RoundedCornerShape(100.dp))
+        )
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -161,10 +161,6 @@ fun NaverMapScreen(
             }
         }
 
-        if (isMarkerClicked) {
-            onMarkerChanged(clickedMarkerId)
-        }
-
         if (isFilteredMarker) {
             FilteredMarkers(
                 (storeDetailData as UiState.Success).data.first(),

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -194,6 +194,9 @@ fun NaverMapScreen(
                 )
             }
             onListItemChanged(false)
+            if (selectedLocationButton == LocationTrackingButton.FOLLOW || selectedLocationButton == LocationTrackingButton.FACE) {
+                onLocationButtonChanged(LocationTrackingButton.NO_FOLLOW)
+            }
         }
     }
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -30,6 +30,8 @@ import com.example.presentation.util.MainConstants.KIND_STORE
 import com.example.presentation.util.MainConstants.LOCATION_SIZE
 import com.example.presentation.util.MainConstants.UN_MARKER
 import com.example.presentation.util.UiState
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.CameraUpdateReason
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
@@ -66,6 +68,9 @@ fun NaverMapScreen(
     isFilteredMarker: Boolean,
     onFilteredMarkerChanged: (Boolean) -> Unit,
     onErrorSnackBarChanged: (String) -> Unit,
+    isListItemClicked: Boolean,
+    onListItemChanged: (Boolean) -> Unit,
+    clickedStoreLocation: Coordinate,
 ) {
     val cameraPositionState = rememberCameraPositionState {
         onOriginCoordinateChanged(
@@ -170,6 +175,17 @@ fun NaverMapScreen(
                 clickedMarkerId,
                 onMarkerChanged
             )
+        }
+
+        if (isListItemClicked) {
+            val zoom = cameraPositionState.position.zoom
+            cameraPositionState.position = CameraPosition(
+                LatLng(
+                    clickedStoreLocation.latitude,
+                    clickedStoreLocation.longitude
+                ), zoom
+            )
+            onListItemChanged(false)
         }
     }
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -31,7 +32,8 @@ import com.example.presentation.util.MainConstants.LOCATION_SIZE
 import com.example.presentation.util.MainConstants.UN_MARKER
 import com.example.presentation.util.UiState
 import com.naver.maps.geometry.LatLng
-import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.CameraAnimation
+import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.CameraUpdateReason
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
@@ -41,8 +43,9 @@ import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberFusedLocationSource
+import kotlinx.coroutines.launch
 
-@SuppressLint("StateFlowValueCalledInComposition")
+@SuppressLint("StateFlowValueCalledInComposition", "CoroutineCreationDuringComposition")
 @ExperimentalNaverMapApi
 @Composable
 fun NaverMapScreen(
@@ -86,6 +89,8 @@ fun NaverMapScreen(
             )
         )
     }
+
+    val scope = rememberCoroutineScope()
 
     NaverMap(
         modifier = Modifier.fillMaxSize(),
@@ -178,13 +183,16 @@ fun NaverMapScreen(
         }
 
         if (isListItemClicked) {
-            val zoom = cameraPositionState.position.zoom
-            cameraPositionState.position = CameraPosition(
-                LatLng(
-                    clickedStoreLocation.latitude,
-                    clickedStoreLocation.longitude
-                ), zoom
-            )
+            scope.launch {
+                cameraPositionState.animate(
+                    CameraUpdate.scrollTo(
+                        LatLng(
+                            clickedStoreLocation.latitude,
+                            clickedStoreLocation.longitude
+                        )
+                    ), CameraAnimation.Easing, 1000
+                )
+            }
             onListItemChanged(false)
         }
     }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -136,7 +136,10 @@ fun StoreListContent(
         itemsIndexed(
             when (val state = storeDetailData) {
                 is UiState.Success -> {
-                    state.data.first().map { it.toUiModel() }
+                    state.data.first().filter {
+                        viewModel.getFilterSet().intersect(it.certificationName.toSet())
+                            .isNotEmpty()
+                    }
                 }
 
                 else -> {
@@ -145,7 +148,7 @@ fun StoreListContent(
             }
         ) { _, item ->
             StoreListItem(
-                item,
+                item.toUiModel(),
                 onBottomSheetChanged,
                 onStoreInfoChanged,
                 onMarkerChanged,

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.R
 import com.example.presentation.mapper.toUiModel
 import com.example.presentation.model.ExpandedType
+import com.example.presentation.model.StoreDetail
 import com.example.presentation.ui.component.BottomSheetDragHandle
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
@@ -45,7 +46,10 @@ import kotlinx.coroutines.launch
 @Composable
 fun StoreListBottomSheet(
     bottomSheetExpandedType: ExpandedType,
-    onBottomSheetExpandedChanged: (ExpandedType) -> Unit
+    onBottomSheetExpandedChanged: (ExpandedType) -> Unit,
+    onBottomSheetChanged: (Boolean) -> Unit,
+    onStoreInfoChanged: (StoreDetail) -> Unit,
+    onMarkerChanged: (Long) -> Unit
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
 
@@ -58,7 +62,7 @@ fun StoreListBottomSheet(
         scaffoldState = scaffoldState,
         sheetContent = {
             StoreListHeader()
-            StoreListContent()
+            StoreListContent(onBottomSheetChanged, onStoreInfoChanged, onMarkerChanged)
         },
         sheetPeekHeight = (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp,
         sheetContainerColor = White,
@@ -110,7 +114,12 @@ fun StoreListHeader() {
 }
 
 @Composable
-fun StoreListContent(viewModel: MapViewModel = hiltViewModel()) {
+fun StoreListContent(
+    onBottomSheetChanged: (Boolean) -> Unit,
+    onStoreInfoChanged: (StoreDetail) -> Unit,
+    onMarkerChanged: (Long) -> Unit,
+    viewModel: MapViewModel = hiltViewModel()
+) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val storeDetailData by viewModel.storeDetailModelData.collectAsStateWithLifecycle(
         lifecycleOwner
@@ -128,7 +137,7 @@ fun StoreListContent(viewModel: MapViewModel = hiltViewModel()) {
                 }
             }
         ) { _, item ->
-            StoreListItem(storeInfo = item)
+            StoreListItem(item, onBottomSheetChanged, onStoreInfoChanged, onMarkerChanged)
             StoreListDivider()
         }
     }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -87,7 +87,7 @@ fun StoreListBottomSheet(
             }
         }
 
-        if (bottomSheetHeight >= (LIST_BOTTOM_SHEET_EXPAND_HEIGHT + LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT).dp / 2) {
+        if (bottomSheetHeight > (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp) {
             onBottomSheetExpandedChanged(ExpandedType.FULL)
         } else {
             onBottomSheetExpandedChanged(ExpandedType.COLLAPSED)

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -6,25 +6,37 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.R
+import com.example.presentation.mapper.toUiModel
+import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
+import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT
+import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_EXPAND_HEIGHT
+import com.example.presentation.util.UiState
 
 @Preview
 @OptIn(ExperimentalMaterial3Api::class)
@@ -33,8 +45,9 @@ fun StoreListBottomSheet() {
     BottomSheetScaffold(
         sheetContent = {
             StoreListHeader()
+            StoreListContent()
         },
-        sheetPeekHeight = (38 + HANDLE_HEIGHT).dp,
+        sheetPeekHeight = (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp,
         sheetContainerColor = White,
         sheetShape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
         sheetShadowElevation = 5.dp,
@@ -69,5 +82,29 @@ fun StoreListHeader() {
             fontSize = 12.sp,
             fontWeight = FontWeight.Medium
         )
+    }
+}
+
+@Composable
+fun StoreListContent(viewModel: MapViewModel = hiltViewModel()) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val storeDetailData by viewModel.storeDetailModelData.collectAsStateWithLifecycle(
+        lifecycleOwner
+    )
+
+    LazyColumn(modifier = Modifier.heightIn(max = LIST_BOTTOM_SHEET_EXPAND_HEIGHT.dp)) {
+        itemsIndexed(
+            when (val state = storeDetailData) {
+                is UiState.Success -> {
+                    state.data.first().map { it.toUiModel() }
+                }
+                else -> {
+                    emptyList()
+                }
+            }
+        ) { _, item ->
+            StoreListItem(storeInfo = item)
+            StoreListDivider()
+        }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -38,6 +38,7 @@ import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_EXPAND_HEIGHT
+import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_FULL_PADDING
 import com.example.presentation.util.UiState
 import kotlinx.coroutines.launch
 
@@ -87,8 +88,10 @@ fun StoreListBottomSheet(
             }
         }
 
-        if (bottomSheetHeight > (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp) {
+        if (bottomSheetHeight > (LIST_BOTTOM_SHEET_FULL_PADDING + LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp) {
             onBottomSheetExpandedChanged(ExpandedType.FULL)
+        } else if (bottomSheetHeight > (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp) {
+            onBottomSheetExpandedChanged(ExpandedType.HALF)
         } else {
             onBottomSheetExpandedChanged(ExpandedType.COLLAPSED)
         }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -1,14 +1,9 @@
 package com.example.presentation.ui.map.list
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,9 +24,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.R
 import com.example.presentation.mapper.toUiModel
+import com.example.presentation.ui.component.BottomSheetDragHandle
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
-import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT
@@ -51,19 +46,8 @@ fun StoreListBottomSheet() {
         sheetContainerColor = White,
         sheetShape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
         sheetShadowElevation = 5.dp,
-        sheetDragHandle = {
-            Column {
-                Spacer(modifier = Modifier.height(10.dp))
-                Box(
-                    modifier = Modifier
-                        .width(34.dp)
-                        .height(4.dp)
-                        .background(SemiLightGray, shape = RoundedCornerShape(100.dp))
-                )
-            }
-        }
+        sheetDragHandle = { BottomSheetDragHandle() }
     ) {
-
     }
 }
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -1,0 +1,73 @@
+package com.example.presentation.ui.map.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.presentation.R
+import com.example.presentation.ui.theme.Black
+import com.example.presentation.ui.theme.SemiLightGray
+import com.example.presentation.ui.theme.White
+import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
+
+@Preview
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StoreListBottomSheet() {
+    BottomSheetScaffold(
+        sheetContent = {
+            StoreListHeader()
+        },
+        sheetPeekHeight = (38 + HANDLE_HEIGHT).dp,
+        sheetContainerColor = White,
+        sheetShape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
+        sheetShadowElevation = 5.dp,
+        sheetDragHandle = {
+            Column {
+                Spacer(modifier = Modifier.height(10.dp))
+                Box(
+                    modifier = Modifier
+                        .width(34.dp)
+                        .height(4.dp)
+                        .background(SemiLightGray, shape = RoundedCornerShape(100.dp))
+                )
+            }
+        }
+    ) {
+
+    }
+}
+
+@Preview
+@Composable
+fun StoreListHeader() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .padding(top = 9.dp, bottom = 14.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = stringResource(R.string.gather_the_stores),
+            color = Black,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -49,7 +49,8 @@ fun StoreListBottomSheet(
     onBottomSheetExpandedChanged: (ExpandedType) -> Unit,
     onBottomSheetChanged: (Boolean) -> Unit,
     onStoreInfoChanged: (StoreDetail) -> Unit,
-    onMarkerChanged: (Long) -> Unit
+    onMarkerChanged: (Long) -> Unit,
+    onListItemChanged: (Boolean) -> Unit
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
 
@@ -62,7 +63,12 @@ fun StoreListBottomSheet(
         scaffoldState = scaffoldState,
         sheetContent = {
             StoreListHeader()
-            StoreListContent(onBottomSheetChanged, onStoreInfoChanged, onMarkerChanged)
+            StoreListContent(
+                onBottomSheetChanged,
+                onStoreInfoChanged,
+                onMarkerChanged,
+                onListItemChanged
+            )
         },
         sheetPeekHeight = (LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT + HANDLE_HEIGHT).dp,
         sheetContainerColor = White,
@@ -118,6 +124,7 @@ fun StoreListContent(
     onBottomSheetChanged: (Boolean) -> Unit,
     onStoreInfoChanged: (StoreDetail) -> Unit,
     onMarkerChanged: (Long) -> Unit,
+    onListItemChanged: (Boolean) -> Unit,
     viewModel: MapViewModel = hiltViewModel()
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -137,7 +144,13 @@ fun StoreListContent(
                 }
             }
         ) { _, item ->
-            StoreListItem(item, onBottomSheetChanged, onStoreInfoChanged, onMarkerChanged)
+            StoreListItem(
+                item,
+                onBottomSheetChanged,
+                onStoreInfoChanged,
+                onMarkerChanged,
+                onListItemChanged
+            )
             StoreListDivider()
         }
     }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
@@ -26,7 +26,8 @@ fun StoreListItem(
     storeInfo: StoreDetail,
     onBottomSheetChanged: (Boolean) -> Unit,
     onStoreInfoChanged: (StoreDetail) -> Unit,
-    onMarkerChanged: (Long) -> Unit
+    onMarkerChanged: (Long) -> Unit,
+    onListItemChanged: (Boolean) -> Unit
 ) {
     BoxWithConstraints {
         ConstraintLayout(
@@ -38,6 +39,7 @@ fun StoreListItem(
                     onBottomSheetChanged(true)
                     onStoreInfoChanged(storeInfo)
                     onMarkerChanged(storeInfo.id)
+                    onListItemChanged(true)
                 },
             constraintSet = setBottomSheetConstraints()
         ) {

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
@@ -1,5 +1,6 @@
 package com.example.presentation.ui.map.list
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,14 +23,22 @@ import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
 
 @Composable
 fun StoreListItem(
-    storeInfo: StoreDetail
+    storeInfo: StoreDetail,
+    onBottomSheetChanged: (Boolean) -> Unit,
+    onStoreInfoChanged: (StoreDetail) -> Unit,
+    onMarkerChanged: (Long) -> Unit
 ) {
     BoxWithConstraints {
         ConstraintLayout(
             modifier = Modifier
                 .padding(horizontal = DEFAULT_MARGIN.dp, vertical = DEFAULT_MARGIN.dp)
                 .fillMaxWidth(1f)
-                .wrapContentHeight(),
+                .wrapContentHeight()
+                .clickable {
+                    onBottomSheetChanged(true)
+                    onStoreInfoChanged(storeInfo)
+                    onMarkerChanged(storeInfo.id)
+                },
             constraintSet = setBottomSheetConstraints()
         ) {
             StoreTitleText(storeInfo.displayName, 18, "storeTitle")

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListComponent.kt
@@ -4,83 +4,21 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.Dimension
-import com.example.presentation.model.Coordinate
 import com.example.presentation.model.StoreDetail
-import com.example.presentation.model.StoreType
 import com.example.presentation.ui.component.StoreImageCard
-import com.example.presentation.ui.component.StoreTitleText
 import com.example.presentation.ui.component.StorePrimaryTypeText
+import com.example.presentation.ui.component.StoreTitleText
 import com.example.presentation.ui.component.StoreTypeChips
 import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.util.MainConstants.BOTTOM_SHEET_STORE_LIST_IMG_SIZE
 import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
-
-@Preview
-@Composable
-fun test() {
-    LazyColumn {
-        itemsIndexed(
-            listOf(
-                StoreDetail(
-                    id = 0,
-                    displayName = "성산일출봉 청운식당Cheongwon",
-                    primaryTypeDisplayName = "일본 음식점",
-                    formattedAddress = "주소",
-                    phoneNumber = "전화",
-                    location = Coordinate(latitude = 0.0, longitude = 0.0),
-                    operatingType = "타입",
-                    timeDescription = "타임",
-                    localPhotos = listOf(),
-                    certificationName = listOf(StoreType.GREAT, StoreType.KIND, StoreType.SAFE),
-                    operationTimeOfWeek = mapOf()
-
-                ),
-                StoreDetail(
-                    id = 0,
-                    displayName = "성산일출봉 청운식당Cheongwon",
-                    primaryTypeDisplayName = "일본 음식점",
-                    formattedAddress = "주소",
-                    phoneNumber = "전화",
-                    location = Coordinate(latitude = 0.0, longitude = 0.0),
-                    operatingType = "타입",
-                    timeDescription = "타임",
-                    localPhotos = listOf(),
-                    certificationName = listOf(StoreType.GREAT, StoreType.KIND, StoreType.SAFE),
-                    operationTimeOfWeek = mapOf()
-
-                ),
-                StoreDetail(
-                    id = 0,
-                    displayName = "성산일출봉 청운식당Cheongwon",
-                    primaryTypeDisplayName = "일본 음식점",
-                    formattedAddress = "주소",
-                    phoneNumber = "전화",
-                    location = Coordinate(latitude = 0.0, longitude = 0.0),
-                    operatingType = "타입",
-                    timeDescription = "타임",
-                    localPhotos = listOf(),
-                    certificationName = listOf(StoreType.GREAT, StoreType.KIND, StoreType.SAFE),
-                    operationTimeOfWeek = mapOf()
-                )
-
-            )
-        ) { idx, item ->
-            StoreListItem(storeInfo = item)
-            StoreListDivider()
-        }
-    }
-}
-
 
 @Composable
 fun StoreListItem(

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
@@ -33,6 +33,7 @@ import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
+import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT
 import com.example.presentation.util.MainConstants.RELOAD_BUTTON_DEFAULT_PADDING
 import com.example.presentation.util.MainConstants.UN_MARKER
 
@@ -104,5 +105,5 @@ fun ReloadButton(
 
 fun setReloadButtonBottomPadding(isMarkerClicked: Boolean, bottomSheetHeight: Dp): Dp {
     return if (isMarkerClicked) bottomSheetHeight + (RELOAD_BUTTON_DEFAULT_PADDING + HANDLE_HEIGHT).dp
-    else RELOAD_BUTTON_DEFAULT_PADDING.dp
+    else (RELOAD_BUTTON_DEFAULT_PADDING + HANDLE_HEIGHT + LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT).dp
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/summary/StoreSummaryBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/summary/StoreSummaryBottomSheet.kt
@@ -4,12 +4,8 @@ import android.annotation.SuppressLint
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,8 +21,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.presentation.model.ExpandedType
 import com.example.presentation.model.StoreDetail
+import com.example.presentation.ui.component.BottomSheetDragHandle
 import com.example.presentation.ui.map.detail.StoreDetailInfo
-import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.BOTTOM_SHEET_ANIMATION_MILLIS
 import com.example.presentation.util.MainConstants.DETAIL_BOTTOM_SHEET_HEIGHT
@@ -70,17 +66,7 @@ fun StoreSummaryBottomSheet(
         sheetContainerColor = White,
         sheetShape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
         sheetShadowElevation = 5.dp,
-        sheetDragHandle = {
-            Column {
-                Spacer(modifier = Modifier.height(10.dp))
-                Box(
-                    modifier = Modifier
-                        .width(34.dp)
-                        .height(4.dp)
-                        .background(SemiLightGray, shape = RoundedCornerShape(100.dp))
-                )
-            }
-        }
+        sheetDragHandle = { BottomSheetDragHandle() }
     ) {
         val density = LocalDensity.current
         val bottomSheetHeight = with(density) {

--- a/presentation/src/main/java/com/example/presentation/ui/map/summary/StoreSummaryBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/summary/StoreSummaryBottomSheet.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -40,11 +38,7 @@ fun StoreSummaryBottomSheet(
     bottomSheetExpandedType: ExpandedType,
     onBottomSheetExpandedChanged: (ExpandedType) -> Unit
 ) {
-    val bottomSheetSt = rememberStandardBottomSheetState(
-        skipHiddenState = true,
-        initialValue = SheetValue.PartiallyExpanded
-    )
-    val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetSt)
+    val scaffoldState = rememberBottomSheetScaffoldState()
 
     val configuration = LocalConfiguration.current
     val screenHeight = configuration.screenHeightDp

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -10,6 +10,8 @@ object MainConstants {
     const val LOCATION_SIZE = 8
     const val UN_MARKER = -1L
     const val DETAIL_BOTTOM_SHEET_HEIGHT = 530
+    const val LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT = 38
+    const val LIST_BOTTOM_SHEET_EXPAND_HEIGHT = 586
     const val HANDLE_HEIGHT = 14
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -12,6 +12,7 @@ object MainConstants {
     const val DETAIL_BOTTOM_SHEET_HEIGHT = 530
     const val LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT = 38
     const val LIST_BOTTOM_SHEET_EXPAND_HEIGHT = 586
+    const val LIST_BOTTOM_SHEET_FULL_PADDING = 50
     const val HANDLE_HEIGHT = 14
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="closed">영업 종료</string>
     <string name="day_off">휴무일</string>
     <string name="break_time">브레이크 타임</string>
+    <string name="gather_the_stores">가게 모아보기</string>
 </resources>


### PR DESCRIPTION
## ⭐️ Issue Number

- #52 

## 🚩 Summary
- 가게 모아보기 BottomSheetScaffold 구현
- 가게 모아보기는 filter된 가게만 보이도록 구현
- Expand시 DimScreen 구현
- List item 클릭시 요약정보 BottomSheet으로 변경
- 요약정보로 이동시 camera focus 가게 좌표로 이동

https://github.com/Korea-Certified-Store/AOS/assets/74500793/207af68a-0454-40ab-a350-35bb430750c7



## 🛠️ Technical Concerns

### Standard Bottom Sheet vs Modal Bottom Sheet
![image](https://github.com/Korea-Certified-Store/AOS/assets/74500793/083e0673-4c18-47d3-8f82-5c69cb002b33)
1번 그림이 Standard Bottom Sheet이고, 2번 그림이 Modal Bottom Sheet입니다.

- **Standard Bottom Sheet**
스크린의 메인 UI 영역과 공존하며, 특히 메인 UI 영역이 자주 스크롤되거나 이동되는 경우 두 영역 모두를 동시에 보고 상호작용할 수 있습니다. 화면 아래 계속되는 보충 컨텐츠에 사용됩니다.

- **Modal Bottom Sheet**
Dialog처럼 앱 컨텐츠 앞에 존재하게 되며, 보여지는 동안 다른 앱 콘텐츠와 상호작용할 수 없습니다. 또한 확인, 해제 등 필요한 작업 수행될 때까지 화면에 남아있습니다. Modal Bottom Sheet는 상호작용하거나 닫혀있어야 합니다. 추가 작업을 표시하기 위해 사용됩니다.

StoreListBottomSheet의 경우, 디테일한 높이 조절이 필요없고 FullScreen했을 때 DimScreen이 필요하기 때문에 Modal Bottom Sheet를 사용해야한다고 생각했습니다.
하지만 Modal Bottom Sheet는 상호작용하거나 닫혀있어야 하기 때문에 `sheetPeekHeight`와 같은 고정 높이가 존재하지 않아StoreListBottomSheet에는 적합하지 않았습니다.
따라서 기존에 사용한 `BottomSheetScaffold`를 사용해서 구현해주었습니다.

[참고](https://m3.material.io/components/bottom-sheets/guidelines)


## 🙂 To Reviwer

- 이번 작업은 지난 작업들을 재활용 많이 하였습니다. 그러다보니 기존 로직을 다시 한번 살펴보았는데요, state들을 viewModel과  composable 함수 중 어디에 두어야할까요? 그 둘을 나누는 기준을 잘 모르겠습니다.. 
- 그리고 파라미터들이 너무 많아져서 줄이는 방향으로 고민을 해보았지만, 최소한의 필요한 정보만을 넘겨주는 것이 맞다고 판단하여 원래대로 유지하였습니다!
- 묘하게 앱이 느려진 것 같은데, 테스트 한번 부탁드립니다!

## 📋 To Do
