### PR TITLE
더보기 버튼 구현

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -63,8 +63,8 @@ class MainActivity : ComponentActivity() {
                         mapViewModel.updateSplashState()
                     }
                     LaunchedEffect(Unit) {
-                        delay(3000L) // 3초 대기
-                        onSplashScreenShowAble(false) // OnboardingScreen 표시 상태 변경
+                        delay(3000L)
+                        onSplashScreenShowAble(false)
                     }
                 } else {
                     if (isSplashScreenShowAble) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -3,12 +3,16 @@ package com.example.presentation.ui
 import android.app.Activity
 import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.model.Contact
 import com.example.presentation.model.Coordinate
 import com.example.presentation.model.ExpandedType
@@ -130,6 +134,8 @@ fun MainScreen(
 
     val (showMoreCount, onShowMoreCountChanged) = remember { mutableStateOf(Pair(-1, 5)) }
 
+    val (isReloadOrShowMoreShowAble, onReloadOrShowMoreChanged) = remember { mutableStateOf(false) }
+
     NaverMapScreen(
         mapViewModel,
         isMarkerClicked,
@@ -156,20 +162,31 @@ fun MainScreen(
         isListItemClicked,
         onListItemChanged,
         clickedStoreInfo.location,
-        onShowMoreCountChanged
+        onShowMoreCountChanged,
+        onReloadOrShowMoreChanged
     )
 
-    ReloadOrShowMoreButton(
-        isMarkerClicked,
-        currentSummaryInfoHeight,
-        isMapGestured,
-        onShowMoreCountChanged,
-        onReloadButtonChanged,
-        onMarkerChanged,
-        onBottomSheetChanged,
-        isLoading,
-        showMoreCount
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val isInitialize by mapViewModel.isInitialize.collectAsStateWithLifecycle(
+        lifecycleOwner
     )
+    LaunchedEffect(key1 = isInitialize) {
+        onReloadButtonChanged(true)
+    }
+
+    if (isReloadOrShowMoreShowAble) {
+        ReloadOrShowMoreButton(
+            isMarkerClicked,
+            currentSummaryInfoHeight,
+            isMapGestured,
+            onShowMoreCountChanged,
+            onReloadButtonChanged,
+            onMarkerChanged,
+            onBottomSheetChanged,
+            isLoading,
+            showMoreCount
+        )
+    }
 
     FilterComponent(
         isKindFilterClicked,

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -19,7 +19,7 @@ import com.example.presentation.ui.map.NaverMapScreen
 import com.example.presentation.ui.map.call.StoreCallDialog
 import com.example.presentation.ui.map.filter.FilterComponent
 import com.example.presentation.ui.map.list.StoreListBottomSheet
-import com.example.presentation.ui.map.reload.ReloadButton
+import com.example.presentation.ui.map.reload.ReloadOrShowMoreButton
 import com.example.presentation.ui.map.summary.DimScreen
 import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
 import com.example.presentation.util.MainConstants
@@ -128,6 +128,8 @@ fun MainScreen(
 
     val (isListItemClicked, onListItemChanged) = remember { mutableStateOf(false) }
 
+    val (showMoreCount, onShowMoreCountChanged) = remember { mutableStateOf(Pair(-1, 5)) }
+
     NaverMapScreen(
         mapViewModel,
         isMarkerClicked,
@@ -153,19 +155,21 @@ fun MainScreen(
         onErrorSnackBarChanged,
         isListItemClicked,
         onListItemChanged,
-        clickedStoreInfo.location
+        clickedStoreInfo.location,
+        onShowMoreCountChanged
     )
 
-    if (isMapGestured) {
-        ReloadButton(
-            isMarkerClicked,
-            onReloadButtonChanged,
-            currentSummaryInfoHeight,
-            onMarkerChanged,
-            onBottomSheetChanged,
-            isLoading
-        )
-    }
+    ReloadOrShowMoreButton(
+        isMarkerClicked,
+        currentSummaryInfoHeight,
+        isMapGestured,
+        onShowMoreCountChanged,
+        onReloadButtonChanged,
+        onMarkerChanged,
+        onBottomSheetChanged,
+        isLoading,
+        showMoreCount
+    )
 
     FilterComponent(
         isKindFilterClicked,

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -3,16 +3,12 @@ package com.example.presentation.ui
 import android.app.Activity
 import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.model.Contact
 import com.example.presentation.model.Coordinate
 import com.example.presentation.model.ExpandedType
@@ -165,14 +161,6 @@ fun MainScreen(
         onShowMoreCountChanged,
         onReloadOrShowMoreChanged
     )
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val isInitialize by mapViewModel.isInitialize.collectAsStateWithLifecycle(
-        lifecycleOwner
-    )
-    LaunchedEffect(key1 = isInitialize) {
-        onReloadButtonChanged(true)
-    }
 
     if (isReloadOrShowMoreShowAble) {
         ReloadOrShowMoreButton(

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -41,6 +41,19 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     private val _isLocationPermissionGranted = MutableStateFlow<Boolean>(false)
     val isLocationPermissionGranted: StateFlow<Boolean> get() = _isLocationPermissionGranted
 
+    val flattenedStoreDetailList: MutableStateFlow<List<StoreDetail>> =
+        MutableStateFlow(emptyList())
+
+    fun showMoreStore(count: Int) {
+        val newItem: List<StoreDetail> = when (val uiState = _storeDetailModelData.value) {
+            is UiState.Success -> uiState.data.getOrNull(count) ?: emptyList()
+            else -> emptyList()
+        }
+        val currentList = flattenedStoreDetailList.value.toMutableList()
+        newItem.forEach { currentList.add(it) }
+        flattenedStoreDetailList.value = currentList.toList()
+    }
+
     fun updateSplashState() {
         _ableToShowSplashScreen.value = false
     }
@@ -112,6 +125,8 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
                     _storeDetailModelData.value = UiState.Loading
                 }
             }
+            flattenedStoreDetailList.value = emptyList()
+            showMoreStore(0)
         }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -10,6 +10,7 @@ import com.example.domain.model.map.StoreDetail
 import com.example.domain.usecase.GetStoreDetailUseCase
 import com.example.domain.util.Resource
 import com.example.presentation.model.LocationTrackingButton
+import com.example.presentation.util.MainConstants.FAIL_TO_LOAD_DATA
 import com.example.presentation.util.MainConstants.GREAT_STORE
 import com.example.presentation.util.MainConstants.KIND_STORE
 import com.example.presentation.util.MainConstants.SAFE_STORE
@@ -120,7 +121,7 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
 
                 is Resource.Failure -> {
                     _storeDetailModelData.value =
-                        UiState.Failure(result.message ?: "데이터를 불러올 수 없습니다")
+                        UiState.Failure(result.message ?: FAIL_TO_LOAD_DATA)
                 }
 
                 is Resource.Loading -> {

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -38,11 +38,13 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     val storeDetailModelData: StateFlow<UiState<List<List<StoreDetail>>>> =
         _storeDetailModelData.asStateFlow()
 
-    private val _isLocationPermissionGranted = MutableStateFlow<Boolean>(false)
+    private val _isLocationPermissionGranted = MutableStateFlow(false)
     val isLocationPermissionGranted: StateFlow<Boolean> get() = _isLocationPermissionGranted
 
     val flattenedStoreDetailList: MutableStateFlow<List<StoreDetail>> =
         MutableStateFlow(emptyList())
+
+    val isInitialize = MutableStateFlow(true)
 
     fun showMoreStore(count: Int) {
         val newItem: List<StoreDetail> = when (val uiState = _storeDetailModelData.value) {
@@ -126,7 +128,11 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
                 }
             }
             flattenedStoreDetailList.value = emptyList()
-            showMoreStore(0)
+            if (isInitialize.value) {
+                flattenedStoreDetailList.value = result.data?.flatten() ?: emptyList()
+            } else {
+                showMoreStore(0)
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -74,6 +74,7 @@ fun NaverMapScreen(
     isListItemClicked: Boolean,
     onListItemChanged: (Boolean) -> Unit,
     clickedStoreLocation: Coordinate,
+    onShowMoreCountChanged: (Pair<Int, Int>) -> Unit,
 ) {
     val cameraPositionState = rememberCameraPositionState {
         onOriginCoordinateChanged(
@@ -159,6 +160,7 @@ fun NaverMapScreen(
                     onFilteredMarkerChanged(true)
                     onLoadingChanged(false)
                     onCurrentMapChanged(false)
+                    onShowMoreCountChanged(Pair(0, state.data.size))
                 }
 
                 is UiState.Failure -> {
@@ -173,7 +175,7 @@ fun NaverMapScreen(
 
         if (isFilteredMarker) {
             FilteredMarkers(
-                (storeDetailData as UiState.Success).data.first(),
+                mapViewModel.flattenedStoreDetailList.value,
                 mapViewModel,
                 onBottomSheetChanged,
                 onStoreInfoChanged,

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -75,6 +75,7 @@ fun NaverMapScreen(
     onListItemChanged: (Boolean) -> Unit,
     clickedStoreLocation: Coordinate,
     onShowMoreCountChanged: (Pair<Int, Int>) -> Unit,
+    onReloadOrShowMoreChanged: (Boolean) -> Unit,
 ) {
     val cameraPositionState = rememberCameraPositionState {
         onOriginCoordinateChanged(
@@ -105,7 +106,7 @@ fun NaverMapScreen(
             isCompassEnabled = false
         ),
         cameraPositionState = cameraPositionState.apply {
-            setNewCoordinateIfGestured(this, onNewCoordinateChanged)
+            setNewCoordinateAndShowReloadButtonIfGestured(this, onNewCoordinateChanged, onReloadOrShowMoreChanged)
             if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.GESTURE
                 && selectedLocationButton.mode != LocationTrackingMode.None
                 && selectedLocationButton.mode != LocationTrackingMode.NoFollow
@@ -154,7 +155,7 @@ fun NaverMapScreen(
                 }
 
                 is UiState.Success -> {
-                    if (mapViewModel.ableToShowSplashScreen.value) {
+                    if (mapViewModel.ableToShowSplashScreen.value && state.data.isNotEmpty()) {
                         onSplashScreenShowAble(false)
                     }
                     onFilteredMarkerChanged(true)
@@ -286,11 +287,13 @@ fun InitializeMarker(
     }
 }
 
-fun setNewCoordinateIfGestured(
+fun setNewCoordinateAndShowReloadButtonIfGestured(
     cameraPositionState: CameraPositionState,
-    onNewCoordinateChanged: (Coordinate) -> Unit
+    onNewCoordinateChanged: (Coordinate) -> Unit,
+    onReloadOrShowMoreChanged: (Boolean) -> Unit
 ) {
     if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.GESTURE) {
+        onReloadOrShowMoreChanged(true)
         onNewCoordinateChanged(
             Coordinate(
                 cameraPositionState.position.target.latitude,

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -39,7 +39,6 @@ import com.example.presentation.util.MainConstants.HANDLE_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_EXPAND_HEIGHT
 import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_FULL_PADDING
-import com.example.presentation.util.UiState
 import kotlinx.coroutines.launch
 
 @SuppressLint("CoroutineCreationDuringComposition")
@@ -131,23 +130,15 @@ fun StoreListContent(
     viewModel: MapViewModel = hiltViewModel()
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val storeDetailData by viewModel.storeDetailModelData.collectAsStateWithLifecycle(
+    val storeDetailData by viewModel.flattenedStoreDetailList.collectAsStateWithLifecycle(
         lifecycleOwner
     )
 
     LazyColumn(modifier = Modifier.heightIn(max = LIST_BOTTOM_SHEET_EXPAND_HEIGHT.dp)) {
         itemsIndexed(
-            when (val state = storeDetailData) {
-                is UiState.Success -> {
-                    state.data.first().filter {
-                        viewModel.getFilterSet().intersect(it.certificationName.toSet())
-                            .isNotEmpty()
-                    }
-                }
-
-                else -> {
-                    emptyList()
-                }
+            storeDetailData.filter {
+                viewModel.getFilterSet().intersect(it.certificationName.toSet())
+                    .isNotEmpty()
             }
         ) { _, item ->
             StoreListItem(

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
@@ -58,14 +58,14 @@ fun ReloadButton(
             if (isLoading) {
                 LoadingAnimation()
             } else {
-                reloadInCurrentLocation()
+                ReloadInCurrentLocation()
             }
         }
     }
 }
 
 @Composable
-private fun reloadInCurrentLocation() {
+private fun ReloadInCurrentLocation() {
     Icon(
         imageVector = ImageVector.vectorResource(id = R.drawable.search),
         tint = Blue,

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
@@ -49,7 +49,7 @@ fun ReloadButton(
             onBottomSheetChanged(false)
         },
         modifier = Modifier
-            .size(width = 110.dp, height = 35.dp),
+            .size(width = 125.dp, height = 35.dp),
         contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = White,

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
@@ -1,24 +1,16 @@
 package com.example.presentation.ui.map.reload
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -37,70 +29,55 @@ import com.example.presentation.util.MainConstants.LIST_BOTTOM_SHEET_COLLAPSE_HE
 import com.example.presentation.util.MainConstants.RELOAD_BUTTON_DEFAULT_PADDING
 import com.example.presentation.util.MainConstants.UN_MARKER
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReloadButton(
-    isMarkerClicked: Boolean,
     onReloadButtonChanged: (Boolean) -> Unit,
-    bottomSheetHeight: Dp,
     onMarkerChanged: (Long) -> Unit,
     onBottomSheetChanged: (Boolean) -> Unit,
     isLoading: Boolean
 ) {
-    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
-        Column(
-            modifier = Modifier
-                .fillMaxHeight()
-                .fillMaxWidth()
-                .padding(
-                    bottom = setReloadButtonBottomPadding(
-                        isMarkerClicked,
-                        bottomSheetHeight
-                    )
-                ),
-            verticalArrangement = Arrangement.Bottom,
-            horizontalAlignment = Alignment.CenterHorizontally
+    Button(
+        onClick = {
+            onReloadButtonChanged(true)
+            onMarkerChanged(UN_MARKER)
+            onBottomSheetChanged(false)
+        },
+        modifier = Modifier
+            .size(width = 110.dp, height = 35.dp),
+        contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = White,
+            contentColor = Black
+        ),
+        shape = RoundedCornerShape(30.dp),
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.align(Alignment.CenterVertically)
         ) {
-            Button(
-                onClick = {
-                    onReloadButtonChanged(true)
-                    onMarkerChanged(UN_MARKER)
-                    onBottomSheetChanged(false)
-                },
-                modifier = Modifier
-                    .size(width = 110.dp, height = 35.dp)
-                    .align(Alignment.CenterHorizontally),
-                contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = White,
-                    contentColor = Black
-                ),
-                shape = RoundedCornerShape(30.dp),
-                elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
-            ) {
-                Row(
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                ) {
-                    if (isLoading) {
-                        LoadingAnimation()
-                    } else {
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = R.drawable.search),
-                            tint = Blue,
-                            contentDescription = "Search",
-                            modifier = Modifier.size(13.dp)
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = stringResource(R.string.search_on_current_map),
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Normal
-                        )
-                    }
-                }
+            if (isLoading) {
+                LoadingAnimation()
+            } else {
+                reloadInCurrentLocation()
             }
         }
     }
+}
+
+@Composable
+private fun reloadInCurrentLocation() {
+    Icon(
+        imageVector = ImageVector.vectorResource(id = R.drawable.search),
+        tint = Blue,
+        contentDescription = "Search",
+        modifier = Modifier.size(13.dp)
+    )
+    Spacer(modifier = Modifier.width(6.dp))
+    Text(
+        text = stringResource(R.string.search_on_current_map),
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Medium
+    )
 }
 
 fun setReloadButtonBottomPadding(isMarkerClicked: Boolean, bottomSheetHeight: Dp): Dp {

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadButton.kt
@@ -20,7 +20,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.presentation.R
+import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
@@ -34,10 +36,14 @@ fun ReloadButton(
     onReloadButtonChanged: (Boolean) -> Unit,
     onMarkerChanged: (Long) -> Unit,
     onBottomSheetChanged: (Boolean) -> Unit,
-    isLoading: Boolean
+    isLoading: Boolean,
+    viewModel: MapViewModel = hiltViewModel()
 ) {
     Button(
         onClick = {
+            if (viewModel.isInitialize.value) {
+                viewModel.isInitialize.value = false
+            }
             onReloadButtonChanged(true)
             onMarkerChanged(UN_MARKER)
             onBottomSheetChanged(false)

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadOrShowMoreButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ReloadOrShowMoreButton.kt
@@ -1,0 +1,50 @@
+package com.example.presentation.ui.map.reload
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+
+@Composable
+fun ReloadOrShowMoreButton(
+    isMarkerClicked: Boolean,
+    currentSummaryInfoHeight: Dp,
+    isMapGestured: Boolean,
+    onShowMoreCountChanged: (Pair<Int, Int>) -> Unit,
+    onReloadButtonChanged: (Boolean) -> Unit,
+    onMarkerChanged: (Long) -> Unit,
+    onBottomSheetChanged: (Boolean) -> Unit,
+    isLoading: Boolean,
+    showMoreCount: Pair<Int, Int>
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .fillMaxWidth()
+            .padding(
+                bottom = setReloadButtonBottomPadding(
+                    isMarkerClicked,
+                    currentSummaryInfoHeight
+                )
+            ),
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        if (isMapGestured) {
+            ReloadButton(
+                onReloadButtonChanged,
+                onMarkerChanged,
+                onBottomSheetChanged,
+                isLoading,
+            )
+        } else {
+            ShowMoreButton(showMoreCount, onShowMoreCountChanged)
+        }
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ShowMoreButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ShowMoreButton.kt
@@ -1,0 +1,50 @@
+package com.example.presentation.ui.map.reload
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color.Companion.Gray
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.presentation.ui.map.MapViewModel
+import com.example.presentation.ui.theme.Black
+import com.example.presentation.ui.theme.White
+
+@Composable
+fun ShowMoreButton(
+    showMoreCount: Pair<Int, Int>,
+    onShowMoreCountChanged: (Pair<Int, Int>) -> Unit,
+    viewModel: MapViewModel = hiltViewModel()
+) {
+    Button(
+        onClick = {
+            if (showMoreCount.first + 1 < showMoreCount.second) {
+                viewModel.showMoreStore(showMoreCount.first + 1)
+                onShowMoreCountChanged(Pair(showMoreCount.first + 1, showMoreCount.second))
+            }
+        },
+        modifier = Modifier
+            .size(width = 110.dp, height = 35.dp),
+        contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = White,
+            contentColor = Black
+        ),
+        shape = RoundedCornerShape(30.dp),
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
+    ) {
+        Text(
+            text = "결과 더보기 ${showMoreCount.first + 1}/${showMoreCount.second}",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            color = if (showMoreCount.first == showMoreCount.second - 1) Gray else Black
+        )
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/reload/ShowMoreButton.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/reload/ShowMoreButton.kt
@@ -8,13 +8,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
+import com.example.presentation.ui.theme.MediumGray
 import com.example.presentation.ui.theme.White
 
 @Composable
@@ -44,7 +44,7 @@ fun ShowMoreButton(
             text = "결과 더보기 ${showMoreCount.first + 1}/${showMoreCount.second}",
             fontSize = 11.sp,
             fontWeight = FontWeight.Medium,
-            color = if (showMoreCount.first == showMoreCount.second - 1) Gray else Black
+            color = if (showMoreCount.first == showMoreCount.second - 1) MediumGray else Black
         )
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/onboarding/OnboardingScreen.kt
@@ -38,6 +38,16 @@ import com.example.presentation.R
 import com.example.presentation.ui.theme.SemiDarkBlue
 import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
+import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_1
+import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_2
+import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_3
+import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_4
+import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_5
+import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_1
+import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_2
+import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_3
+import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_4
+import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_5
 
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -67,37 +77,37 @@ fun OnboardingScreen(onOnboardingScreenShowAble: (Boolean) -> Unit) {
 @Composable
 private fun getContentByPageNumber(it: Int) = when (it) {
     0 -> OnboardingPageContent(
-        "인증제 별 가게 위치를\n지도로 한눈에 알아봐요!",
+        ONBOARDING_TITLE_1,
         R.drawable.onboarding_first,
-        "여기서 잠깐,\n인증제에 대해 설명해 드릴게요!"
+        ONBOARDING_EXPLANATION_1
     )
 
     1 ->
         OnboardingPageContent(
-            "착한 가격 업소란?",
+            ONBOARDING_TITLE_2,
             R.drawable.onboarding_second,
-            "\n2011년부터 물가안정을 위해\n가격이 저렴하지만 양질의 서비스를\n제공하는 곳을 정부가 지정한\n우리 동네의 좋은 업소입니다."
+            ONBOARDING_EXPLANATION_2
         )
 
     2 ->
         OnboardingPageContent(
-            "모범 음식점이란?",
+            ONBOARDING_TITLE_3,
             R.drawable.onboarding_third,
-            "식품위생법에 근거하여\n위생관리 상태 등이 우수한 업소를\n모범업소로 지정합니다.\n서비스 수준 향상과 위생적 개선을 도모하기\n위해 운영되고 있습니다."
+            ONBOARDING_EXPLANATION_3
         )
 
     3 ->
         OnboardingPageContent(
-            "안심식당이란?",
+            ONBOARDING_TITLE_4,
             R.drawable.onboarding_fourth,
-            "\n감염병에 취약한 식사문화 개선을 위해\n덜어 먹기, 위생적 수저관리, 종사자 마스크\n착용 및 생활 방역을 준수하는 곳으로\n소재지 지자체의 인증을\n받은 음식점을 의미합니다."
+            ONBOARDING_EXPLANATION_4
         )
 
     4 ->
         OnboardingPageContent(
-            "나인가 시작하기",
+            ONBOARDING_TITLE_5,
             R.drawable.onboarding_fifth,
-            "이젠 정말 나인가와 함께 할 시간이에요!"
+            ONBOARDING_EXPLANATION_5
         )
 
     else -> OnboardingPageContent("", 0, "")

--- a/presentation/src/main/java/com/example/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/onboarding/OnboardingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -38,16 +39,6 @@ import com.example.presentation.R
 import com.example.presentation.ui.theme.SemiDarkBlue
 import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
-import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_1
-import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_2
-import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_3
-import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_4
-import com.example.presentation.util.MainConstants.ONBOARDING_EXPLANATION_5
-import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_1
-import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_2
-import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_3
-import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_4
-import com.example.presentation.util.MainConstants.ONBOARDING_TITLE_5
 
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -77,37 +68,37 @@ fun OnboardingScreen(onOnboardingScreenShowAble: (Boolean) -> Unit) {
 @Composable
 private fun getContentByPageNumber(it: Int) = when (it) {
     0 -> OnboardingPageContent(
-        ONBOARDING_TITLE_1,
+        stringResource(R.string.ONBOARDING_TITLE_1),
         R.drawable.onboarding_first,
-        ONBOARDING_EXPLANATION_1
+        stringResource(R.string.ONBOARDING_EXPLANATION_1)
     )
 
     1 ->
         OnboardingPageContent(
-            ONBOARDING_TITLE_2,
+            stringResource(R.string.ONBOARDING_TITLE_2),
             R.drawable.onboarding_second,
-            ONBOARDING_EXPLANATION_2
+            stringResource(R.string.ONBOARDING_EXPLANATION_2)
         )
 
     2 ->
         OnboardingPageContent(
-            ONBOARDING_TITLE_3,
+            stringResource(R.string.ONBOARDING_TITLE_3),
             R.drawable.onboarding_third,
-            ONBOARDING_EXPLANATION_3
+            stringResource(R.string.ONBOARDING_EXPLANATION_3)
         )
 
     3 ->
         OnboardingPageContent(
-            ONBOARDING_TITLE_4,
+            stringResource(R.string.ONBOARDING_TITLE_4),
             R.drawable.onboarding_fourth,
-            ONBOARDING_EXPLANATION_4
+            stringResource(R.string.ONBOARDING_EXPLANATION_4)
         )
 
     4 ->
         OnboardingPageContent(
-            ONBOARDING_TITLE_5,
+            stringResource(R.string.ONBOARDING_TITLE_5),
             R.drawable.onboarding_fifth,
-            ONBOARDING_EXPLANATION_5
+            stringResource(R.string.ONBOARDING_EXPLANATION_5)
         )
 
     else -> OnboardingPageContent("", 0, "")

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -20,4 +20,18 @@ object MainConstants {
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"
     const val SAFE_STORE = "안심식당"
+    const val FAIL_TO_LOAD_DATA = "데이터를 불러올 수 없습니다"
+    const val ONBOARDING_TITLE_1 = "인증제 별 가게 위치를\n지도로 한눈에 알아봐요!"
+    const val ONBOARDING_EXPLANATION_1 = "여기서 잠깐,\n인증제에 대해 설명해 드릴게요!"
+    const val ONBOARDING_TITLE_2 = "착한 가격 업소란?"
+    const val ONBOARDING_EXPLANATION_2 =
+        "\n2011년부터 물가안정을 위해\n가격이 저렴하지만 양질의 서비스를\n제공하는 곳을 정부가 지정한\n우리 동네의 좋은 업소입니다."
+    const val ONBOARDING_TITLE_3 = "모범 음식점이란?"
+    const val ONBOARDING_EXPLANATION_3 =
+        "식품위생법에 근거하여\n위생관리 상태 등이 우수한 업소를\n모범업소로 지정합니다.\n서비스 수준 향상과 위생적 개선을 도모하기\n위해 운영되고 있습니다."
+    const val ONBOARDING_TITLE_4 = "안심식당이란?"
+    const val ONBOARDING_EXPLANATION_4 =
+        "\n감염병에 취약한 식사문화 개선을 위해\n덜어 먹기, 위생적 수저관리, 종사자 마스크\n착용 및 생활 방역을 준수하는 곳으로\n소재지 지자체의 인증을\n받은 음식점을 의미합니다."
+    const val ONBOARDING_TITLE_5 = "나인가 시작하기"
+    const val ONBOARDING_EXPLANATION_5 = "이젠 정말 나인가와 함께 할 시간이에요!"
 }

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -21,17 +21,4 @@ object MainConstants {
     const val GREAT_STORE = "모범음식점"
     const val SAFE_STORE = "안심식당"
     const val FAIL_TO_LOAD_DATA = "데이터를 불러올 수 없습니다"
-    const val ONBOARDING_TITLE_1 = "인증제 별 가게 위치를\n지도로 한눈에 알아봐요!"
-    const val ONBOARDING_EXPLANATION_1 = "여기서 잠깐,\n인증제에 대해 설명해 드릴게요!"
-    const val ONBOARDING_TITLE_2 = "착한 가격 업소란?"
-    const val ONBOARDING_EXPLANATION_2 =
-        "\n2011년부터 물가안정을 위해\n가격이 저렴하지만 양질의 서비스를\n제공하는 곳을 정부가 지정한\n우리 동네의 좋은 업소입니다."
-    const val ONBOARDING_TITLE_3 = "모범 음식점이란?"
-    const val ONBOARDING_EXPLANATION_3 =
-        "식품위생법에 근거하여\n위생관리 상태 등이 우수한 업소를\n모범업소로 지정합니다.\n서비스 수준 향상과 위생적 개선을 도모하기\n위해 운영되고 있습니다."
-    const val ONBOARDING_TITLE_4 = "안심식당이란?"
-    const val ONBOARDING_EXPLANATION_4 =
-        "\n감염병에 취약한 식사문화 개선을 위해\n덜어 먹기, 위생적 수저관리, 종사자 마스크\n착용 및 생활 방역을 준수하는 곳으로\n소재지 지자체의 인증을\n받은 음식점을 의미합니다."
-    const val ONBOARDING_TITLE_5 = "나인가 시작하기"
-    const val ONBOARDING_EXPLANATION_5 = "이젠 정말 나인가와 함께 할 시간이에요!"
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -16,4 +16,15 @@
     <string name="day_off">휴무일</string>
     <string name="break_time">브레이크 타임</string>
     <string name="gather_the_stores">가게 모아보기</string>
+
+    <string name="ONBOARDING_TITLE_1">인증제 별 가게 위치를\n지도로 한눈에 알아봐요!</string>
+    <string name="ONBOARDING_EXPLANATION_1">여기서 잠깐,\n인증제에 대해 설명해 드릴게요!</string>
+    <string name="ONBOARDING_TITLE_2">착한 가격 업소란?</string>
+    <string name="ONBOARDING_EXPLANATION_2">\n2011년부터 물가안정을 위해\n가격이 저렴하지만 양질의 서비스를\n제공하는 곳을 정부가 지정한\n우리 동네의 좋은 업소입니다.</string>
+    <string name="ONBOARDING_TITLE_3">모범 음식점이란?</string>
+    <string name="ONBOARDING_EXPLANATION_3">식품위생법에 근거하여\n위생관리 상태 등이 우수한 업소를\n모범업소로 지정합니다.\n서비스 수준 향상과 위생적 개선을 도모하기\n위해 운영되고 있습니다.</string>
+    <string name="ONBOARDING_TITLE_4">안심식당이란?</string>
+    <string name="ONBOARDING_EXPLANATION_4">감염병에 취약한 식사문화 개선을 위해\n덜어 먹기, 위생적 수저관리, 종사자 마스크\n착용 및 생활 방역을 준수하는 곳으로\n소재지 지자체의 인증을\n받은 음식점을 의미합니다.</string>
+    <string name="ONBOARDING_TITLE_5">나인가 시작하기</string>
+    <string name="ONBOARDING_EXPLANATION_5">이젠 정말 나인가와 함께 할 시간이에요!</string>
 </resources>


### PR DESCRIPTION
## ⭐️ Issue Number

- #55 

## 🚩 Summary

https://github.com/Korea-Certified-Store/AOS/assets/46596035/ad9b7465-346c-4346-bcd3-f4e164a87931

- [x] 더보기 버튼 layout 구현
- [x] 15번씩 최대 5번까지 더보기 동작 구현
- [x] 가게 리스트 처음 초기화 시 최대 75개 한 번에 불러오기

#### viewModel 변경 사항
- `val storeDetailModelData : StateFlow<UiState<List<List<StoreDetail>>>>` : 기존의 서버 통신 결과를 저장하는 변수
- `val flattenedStoreDetailList : MutableStateFlow<List<StoreDetail>>` : 추가된 가게 리스트들을 저장하는 변수
- `fun showMoreStore(count: Int)` 추가 : 더보기 버튼이 클릭될 때 실행, count를 인덱스로 가게 리스트 추가
- `val isInitialize` : 앱 실행 후 첫번째 초기화인지 아닌지 구별하기 위한 변수

## 🛠️ Technical Concerns

### Concern 1

`현 지도에서 검색` 버튼과 `결과 더보기` 버튼은 위치, 기본적인 레이아웃은 동일하지만 내부 동작 로직이 상이합니다.
따라서 공통된 부분은 ReloadOrShowMoreButton로 구현하고 서로 다른 부분들은 if(isMapGestured)를 통해 각각 ReloadButton과 ShowMoreButton으로 구현해주었습니다.

|버튼|클릭 시 기능|레이아웃|
|-|-|-|
|ReloadButton|현 지도 화면에서 `getStoreDetail`를 실행한다.<br>`flattenedStoreDetailList`, `ShowMoreCount`를 초기화한다|UiState loading시 애니메이션|
|ShowMoreButton|뷰모델의 showMoreStore를 실행해 가게 리스트 데이터 업데이트<br>`ShowMoreCount`(더보기 버튼 클릭 횟수)의 first 값 1씩 증가| `ShowMoreCount`/리스트 사이즈 |

### Concern 2

위치 권한이 있을 경우 앱 최초 실행 시 사용자의 위치로 이동하는데, 이 때 isMapGestured가 true로 변하며 더보기 버튼이 나타나는 이슈가 있었습니다.
따라서 isMapGestured 대신 isReloadOrShowMoreShowAble상태를 새로 만들고, NaverMapScreen의 setNewCoordinateAndShowReloadButtonIfGestured에서 상태를 변경하도록 했습니다.

## 🙂 To Reviwer

- Review Point : 수정한 코드 분량은 적은데 기능과 상태들이 복잡하게 얽혀있어 리뷰하기 어려울 것 같아 최대한 상세히(?) 적어보았습니다..

## 📋 To Do
