### PR TITLE
현위치 이동 및 가게 초기화 로직 수정

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -63,6 +63,7 @@ class MainActivity : ComponentActivity() {
                     if (isOnboardingScreenShowAble) {
                         OnboardingScreen(onOnboardingScreenShowAble)
                     } else {
+                        mapViewModel.updateLocationPermission(false)
                         LocationPermissionRequest(mapViewModel)
                     }
                     if (isSplashScreenShowAble) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : ComponentActivity() {
                     if (isOnboardingScreenShowAble) {
                         OnboardingScreen(onOnboardingScreenShowAble)
                     } else {
-                        mapViewModel.updateLocationPermission(false)
+                        LocationPermissionRequest(mapViewModel)
                     }
                     if (isSplashScreenShowAble) {
                         SplashScreen()

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -64,7 +64,6 @@ class MainActivity : ComponentActivity() {
                         OnboardingScreen(onOnboardingScreenShowAble)
                     } else {
                         mapViewModel.updateLocationPermission(false)
-                        LocationPermissionRequest(mapViewModel)
                     }
                     if (isSplashScreenShowAble) {
                         SplashScreen()

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -3,7 +3,6 @@ package com.example.presentation.ui
 import android.app.Activity
 import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,7 +22,6 @@ import com.example.presentation.ui.map.list.StoreListBottomSheet
 import com.example.presentation.ui.map.reload.ReloadOrShowMoreButton
 import com.example.presentation.ui.map.summary.DimScreen
 import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
-import com.example.presentation.ui.splash.SplashScreen
 import com.example.presentation.util.MainConstants
 import com.example.presentation.util.MainConstants.UN_MARKER
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
@@ -110,8 +108,6 @@ fun MainScreen(
 
     val (clickedMarkerId, onMarkerChanged) = remember { mutableLongStateOf(UN_MARKER) }
 
-    val (initLocationSize, onInitLocationChanged) = remember { mutableIntStateOf(0) }
-
     val (isFilterStateChanged, onFilterStateChanged) = remember { mutableStateOf(false) }
 
     val (bottomSheetExpandedType, onBottomSheetExpandedChanged) = remember {
@@ -146,9 +142,6 @@ fun MainScreen(
         selectedLocationButton,
         onLocationButtonChanged,
         onReloadButtonChanged,
-        initLocationSize,
-        onInitLocationChanged,
-        screenCoordinate,
         onSplashScreenShowAble,
         onLoadingChanged,
         onCurrentMapChanged,

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -12,6 +12,7 @@ import com.example.domain.util.Resource
 import com.example.presentation.model.LocationTrackingButton
 import com.example.presentation.util.MainConstants.FAIL_TO_LOAD_DATA
 import com.example.presentation.util.MainConstants.GREAT_STORE
+import com.example.presentation.util.MainConstants.INITIALIZE_ABLE
 import com.example.presentation.util.MainConstants.KIND_STORE
 import com.example.presentation.util.MainConstants.SAFE_STORE
 import com.example.presentation.util.UiState
@@ -30,7 +31,7 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     private val _ableToShowSplashScreen = MutableStateFlow(true)
     val ableToShowSplashScreen: StateFlow<Boolean> = _ableToShowSplashScreen
 
-    var ableToShowInitialMarker = true
+    var storeInitializeState = INITIALIZE_ABLE
 
     private val filterSet = mutableSetOf<String>()
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -31,8 +31,6 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     private val _ableToShowSplashScreen = MutableStateFlow(true)
     val ableToShowSplashScreen: StateFlow<Boolean> = _ableToShowSplashScreen
 
-    var storeInitializeState = INITIALIZE_ABLE
-
     private val filterSet = mutableSetOf<String>()
 
     private val _storeDetailModelData =
@@ -45,6 +43,9 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
 
     val flattenedStoreDetailList: MutableStateFlow<List<StoreDetail>> =
         MutableStateFlow(emptyList())
+
+    private val _storeInitializeState = MutableStateFlow(INITIALIZE_ABLE)
+    val storeInitializeState: StateFlow<Int> get() = _storeInitializeState
 
     private val _isInitialize = MutableStateFlow(true)
     val isInitialize get() = _isInitialize
@@ -137,6 +138,10 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
                 showMoreStore(0)
             }
         }
+    }
+
+    fun updateStoreInitializeState(state: Int) {
+        _storeInitializeState.value = state
     }
 
     fun updateIsInitialize() {

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -161,7 +161,7 @@ fun NaverMapScreen(
                 is UiState.Success -> {
                     val isInitializationLocation =
                         mapViewModel.isLocationPermissionGranted.value.not()
-                                || (mapViewModel.storeInitializeState == INITIALIZE_DONE)
+                                || (mapViewModel.storeInitializeState.value == INITIALIZE_DONE)
                     if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value && state.data.isNotEmpty()) {
                         onSplashScreenShowAble(false)
                     }
@@ -264,17 +264,19 @@ fun InitializeMarker(
 ) {
     val (initialLocationSetting, onInitialLocationSetting) = remember { mutableStateOf(false) }
     LaunchedEffect(cameraPositionState.isMoving) {
-        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState == INITIALIZE_ABLE
+        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_ABLE
             && cameraPositionState.position.target == LatLng(37.5666102, 126.9783881)
         ) {
             initializeStoreInDefaultLocation(
                 onScreenChanged, mainViewModel, onInitialLocationSetting
             )
         }
-        if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.LOCATION && cameraPositionState.isMoving && mainViewModel.storeInitializeState == INITIALIZE_DEFAULT_DONE) {
+        if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.LOCATION && cameraPositionState.isMoving
+            && mainViewModel.storeInitializeState.value == INITIALIZE_DEFAULT_DONE
+        ) {
             checkInitialMoveByLocation(mainViewModel)
         }
-        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState == INITIALIZE_MOVE_ONCE) {
+        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_MOVE_ONCE) {
             initializeStoreInCurrentLocation(mainViewModel, onInitialLocationSetting)
         }
     }
@@ -310,19 +312,19 @@ private fun initializeStoreInDefaultLocation(
             ),
         )
     )
-    mainViewModel.storeInitializeState = INITIALIZE_DEFAULT_DONE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_DEFAULT_DONE)
     onInitialLocationSetting(true)
 }
 
 private fun checkInitialMoveByLocation(mainViewModel: MapViewModel) {
-    mainViewModel.storeInitializeState = INITIALIZE_MOVE_ONCE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_MOVE_ONCE)
 }
 
 private fun initializeStoreInCurrentLocation(
     mainViewModel: MapViewModel,
     onInitialLocationSetting: (Boolean) -> Unit
 ) {
-    mainViewModel.storeInitializeState = INITIALIZE_DONE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_DONE)
     onInitialLocationSetting(true)
 }
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -30,6 +30,8 @@ import com.example.presentation.model.StoreType
 import com.example.presentation.ui.map.location.CurrentLocationComponent
 import com.example.presentation.ui.map.marker.StoreMarker
 import com.example.presentation.ui.map.reload.setReloadButtonBottomPadding
+import com.example.presentation.util.MainConstants.DEFAULT_LATITUDE
+import com.example.presentation.util.MainConstants.DEFAULT_LONGITUDE
 import com.example.presentation.util.MainConstants.GREAT_STORE
 import com.example.presentation.util.MainConstants.INITIALIZE_ABLE
 import com.example.presentation.util.MainConstants.INITIALIZE_DEFAULT_DONE
@@ -162,7 +164,7 @@ fun NaverMapScreen(
                     val isInitializationLocation =
                         mapViewModel.isLocationPermissionGranted.value.not()
                                 || (mapViewModel.storeInitializeState.value == INITIALIZE_DONE)
-                    if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value && state.data.isNotEmpty()) {
+                    if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value) {
                         onSplashScreenShowAble(false)
                     }
                     onFilteredMarkerChanged(true)
@@ -262,13 +264,13 @@ fun InitializeMarker(
     onScreenChanged: (ScreenCoordinate) -> Unit,
     mainViewModel: MapViewModel = hiltViewModel()
 ) {
-    val (initialLocationSetting, onInitialLocationSetting) = remember { mutableStateOf(false) }
+    val (isInitialLocationSet, onInitialLocationSetChanged) = remember { mutableStateOf(false) }
     LaunchedEffect(cameraPositionState.isMoving) {
         if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_ABLE
-            && cameraPositionState.position.target == LatLng(37.5666102, 126.9783881)
+            && cameraPositionState.position.target == LatLng(DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
         ) {
             initializeStoreInDefaultLocation(
-                onScreenChanged, mainViewModel, onInitialLocationSetting
+                onScreenChanged, mainViewModel, onInitialLocationSetChanged
             )
         }
         if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.LOCATION && cameraPositionState.isMoving
@@ -277,12 +279,12 @@ fun InitializeMarker(
             checkInitialMoveByLocation(mainViewModel)
         }
         if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_MOVE_ONCE) {
-            initializeStoreInCurrentLocation(mainViewModel, onInitialLocationSetting)
+            initializeStoreInCurrentLocation(mainViewModel, onInitialLocationSetChanged)
         }
     }
-    if (initialLocationSetting) {
+    if (isInitialLocationSet) {
         GetScreenCoordinate(cameraPositionState, onScreenChanged)
-        onInitialLocationSetting(false)
+        onInitialLocationSetChanged(false)
         onReloadButtonChanged(true)
     }
 }
@@ -290,7 +292,7 @@ fun InitializeMarker(
 private fun initializeStoreInDefaultLocation(
     onScreenChanged: (ScreenCoordinate) -> Unit,
     mainViewModel: MapViewModel,
-    onInitialLocationSetting: (Boolean) -> Unit
+    onInitialLocationSetChanged: (Boolean) -> Unit
 ) {
     onScreenChanged(
         ScreenCoordinate(
@@ -313,7 +315,7 @@ private fun initializeStoreInDefaultLocation(
         )
     )
     mainViewModel.updateStoreInitializeState(INITIALIZE_DEFAULT_DONE)
-    onInitialLocationSetting(true)
+    onInitialLocationSetChanged(true)
 }
 
 private fun checkInitialMoveByLocation(mainViewModel: MapViewModel) {
@@ -322,10 +324,10 @@ private fun checkInitialMoveByLocation(mainViewModel: MapViewModel) {
 
 private fun initializeStoreInCurrentLocation(
     mainViewModel: MapViewModel,
-    onInitialLocationSetting: (Boolean) -> Unit
+    onInitialLocationSetChanged: (Boolean) -> Unit
 ) {
     mainViewModel.updateStoreInitializeState(INITIALIZE_DONE)
-    onInitialLocationSetting(true)
+    onInitialLocationSetChanged(true)
 }
 
 fun setNewCoordinateAndShowReloadButtonIfGestured(

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -7,7 +7,6 @@ object MainConstants {
     const val BOTTOM_SHEET_STORE_DETAIL_IMG_SIZE = 133
     const val BOTTOM_SHEET_STORE_LIST_IMG_SIZE = 69
     const val DEFAULT_MARGIN = 16
-    const val LOCATION_SIZE = 8
     const val UN_MARKER = -1L
     const val DETAIL_BOTTOM_SHEET_HEIGHT = 530
     const val LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT = 38
@@ -16,6 +15,10 @@ object MainConstants {
     const val HANDLE_HEIGHT = 14
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200
+    const val INITIALIZE_ABLE = -1
+    const val INITIALIZE_MOVE_ONCE = 0
+    const val INITIALIZE_DONE = 1
+    const val INITIALIZE_DEFAULT_DONE = 2
 
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -16,9 +16,9 @@ object MainConstants {
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200
     const val INITIALIZE_ABLE = -1
-    const val INITIALIZE_MOVE_ONCE = 0
-    const val INITIALIZE_DONE = 1
-    const val INITIALIZE_DEFAULT_DONE = 2
+    const val INITIALIZE_DEFAULT_DONE = 0
+    const val INITIALIZE_MOVE_ONCE = 1
+    const val INITIALIZE_DONE = 2
 
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -19,6 +19,8 @@ object MainConstants {
     const val INITIALIZE_DEFAULT_DONE = 0
     const val INITIALIZE_MOVE_ONCE = 1
     const val INITIALIZE_DONE = 2
+    const val DEFAULT_LATITUDE = 37.5666102
+    const val DEFAULT_LONGITUDE = 126.9783881
 
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"


### PR DESCRIPTION
## ⭐️ Issue Number

- #61 

## 🚩 Summary

기존에 LocationSize를 이용한 로직은 보다 먼 거리를 이동할 때 LocationSize가 부족해 현위치까지 도달하지 못하고 중간 지점에서 초기화가 되는 문제가 발생했습니다.
이러한 이슈를 비롯해 Recomposition시 함수가 반복적으로 호출되는 문제도 함께 개선한 새로운 로직으로 수정했습니다.

## 🛠️ Technical Concerns

### 위치 권한 있을 때 현위치로 이동 후 가게 초기화

**현위치로의 이동이 끝났는지**를 알아야하기 때문에 `CameraPositionState`의 `isMoving`를 key로 하는 LaunchedEffect를 이용했습니다.
_isMoving : 카메라가 현재 움직이고 있는지 여부. 이동, 확대/축소 또는 회전과 같은 모든 종류의 이동이 포함됨._

|경우|로직|storeInitializeState 변화|
|-|-|-|
|권한 **X**|1. 앱 실행<br>2. 카메라 움직이지 않음 & INITIALIZE_ABLE & 현위치 종로|1. **INITIALIZE_ABLE**<br>2. **INITIALIZE_DEFAULT_DONE**|
|권한 **O**|1. 앱 실행<br>2. 카메라 움직이지 않음 & INITIALIZE_ABLE & 현위치 종로<br>3. 카메라 움직임 & Reason == Location & INITIALIZE_DEFAULT_DONE<br>4. 카메라 움직이지 않음 & INITIALIZE_MOVE_ONCE|1. **INITIALIZE_ABLE**<br>2. **INITIALIZE_DEFAULT_DONE**<br>3. **INITIALIZE_MOVE_ONCE**<br>4. **INITIALIZE_DONE**|

위 로직을 사용하면 앱 실행 중 권한이 없다가 새롭게 부여되어도 현위치 버튼을 누르면 자연스럽게 3번으로 연결되며 현위치에서 가게가 초기화됩니다.

### 뷰모델 변수 설명
- `val storeInitializeState` : 초기화 시 이동 여부를 -1, 0, 1, 2 네 가지 상태로 표현하는 Int 변수
    - **INITIALIZE_ABLE** = -1
    - **INITIALIZE_DEFAULT_DONE** = 0
    - **INITIALIZE_MOVE_ONCE** = 1
    - **INITIALIZE_DONE** = 2
- `fun updateStoreInitializeState(state: Int)` : `storeInitializeState`를 파라미터 값으로 update하기 위한 메서드
- `val isInitialize` : 초기화 시에는 15개 씩 나누지 않고 한 번에 모든 가게를 띄워주기 위한 Boolean 변수
- `fun updateIsInitialize()` : `isInitialize`를 false로 update하기 위한 메서드

### 수정된 로직에 따른 적절한 Splash 동작 구현

문제 : 권한이 있을 때와 없을 때 모두 INITIALIZE_DEFAULT_DONE 단계를 거치기 때문에 InitializeMarker에서는 구별할 수 없음.
따라서 UiState.Success시 mapViewModel.ableToShowSplashScreen이 true일 때 아래의 조건들을 추가해 Splash 종료 시점을 구별해 줌
- 권한 **X** : mapViewModel.isLocationPermissionGranted.value.not()
- 권한 **O** : mapViewModel.storeInitializeState.value == INITIALIZE_DONE

## 🙂 To Reviwer

## 📋 To Do
