### PR TITLE
제스처 로직 및 화면 좌표 갱신 로직 리팩토링

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -63,6 +63,7 @@ class MainActivity : ComponentActivity() {
                     if (isOnboardingScreenShowAble) {
                         OnboardingScreen(onOnboardingScreenShowAble)
                     } else {
+                        mapViewModel.updateLocationPermission(false)
                         LocationPermissionRequest(mapViewModel)
                     }
                     if (isSplashScreenShowAble) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -56,23 +56,6 @@ fun MainScreen(
     val (isCallClicked, onCallDialogChanged) = remember { mutableStateOf(false) }
     val (isCallDialogCancelClicked, onCallDialogCanceled) = remember { mutableStateOf(false) }
 
-    val (originCoordinate, onOriginCoordinateChanged) = remember {
-        mutableStateOf(
-            Coordinate(
-                0.0,
-                0.0
-            )
-        )
-    }
-    val (newCoordinate, onNewCoordinateChanged) = remember {
-        mutableStateOf(
-            Coordinate(
-                0.0,
-                0.0
-            )
-        )
-    }
-
     val (isMapGestured, onCurrentMapChanged) = remember { mutableStateOf(false) }
     val (isReloadButtonClicked, onReloadButtonChanged) = remember {
         mutableStateOf(false)
@@ -133,8 +116,6 @@ fun MainScreen(
         isMarkerClicked,
         onBottomSheetChanged,
         onStoreInfoChanged,
-        onOriginCoordinateChanged,
-        onNewCoordinateChanged,
         onScreenChanged,
         currentSummaryInfoHeight,
         clickedMarkerId,
@@ -221,10 +202,6 @@ fun MainScreen(
         onCallDialogChanged(false)
     }
 
-    if (originCoordinate != newCoordinate) {
-        onCurrentMapChanged(true)
-    }
-
     if (isReloadButtonClicked) {
         onFilteredMarkerChanged(false)
         onErrorSnackBarChanged("")
@@ -242,7 +219,6 @@ fun MainScreen(
             neLat = screenCoordinate.northEast.latitude
         )
         onReloadButtonChanged(false)
-        onOriginCoordinateChanged(newCoordinate)
     }
 
     if (isFilterStateChanged) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -111,6 +111,12 @@ fun MainScreen(
 
     val (isReloadOrShowMoreShowAble, onReloadOrShowMoreChanged) = remember { mutableStateOf(false) }
 
+    val (isScreenCoordinateChanged, onGetNewScreenCoordinateChanged) = remember {
+        mutableStateOf(
+            false
+        )
+    }
+
     NaverMapScreen(
         mapViewModel,
         isMarkerClicked,
@@ -133,7 +139,9 @@ fun MainScreen(
         onListItemChanged,
         clickedStoreInfo.location,
         onShowMoreCountChanged,
-        onReloadOrShowMoreChanged
+        onReloadOrShowMoreChanged,
+        isReloadButtonClicked,
+        onGetNewScreenCoordinateChanged
     )
 
     if (isReloadOrShowMoreShowAble) {
@@ -202,7 +210,7 @@ fun MainScreen(
         onCallDialogChanged(false)
     }
 
-    if (isReloadButtonClicked) {
+    if (isReloadButtonClicked && isScreenCoordinateChanged) {
         onFilteredMarkerChanged(false)
         onErrorSnackBarChanged("")
         mapViewModel.getStoreDetail(
@@ -219,6 +227,7 @@ fun MainScreen(
             neLat = screenCoordinate.northEast.latitude
         )
         onReloadButtonChanged(false)
+        onGetNewScreenCoordinateChanged(false)
     }
 
     if (isFilterStateChanged) {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -3,7 +3,6 @@ package com.example.presentation.ui
 import android.app.Activity
 import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,7 +22,6 @@ import com.example.presentation.ui.map.list.StoreListBottomSheet
 import com.example.presentation.ui.map.reload.ReloadOrShowMoreButton
 import com.example.presentation.ui.map.summary.DimScreen
 import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
-import com.example.presentation.ui.splash.SplashScreen
 import com.example.presentation.util.MainConstants
 import com.example.presentation.util.MainConstants.UN_MARKER
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
@@ -110,8 +108,6 @@ fun MainScreen(
 
     val (clickedMarkerId, onMarkerChanged) = remember { mutableLongStateOf(UN_MARKER) }
 
-    val (initLocationSize, onInitLocationChanged) = remember { mutableIntStateOf(0) }
-
     val (isFilterStateChanged, onFilterStateChanged) = remember { mutableStateOf(false) }
 
     val (bottomSheetExpandedType, onBottomSheetExpandedChanged) = remember {
@@ -146,9 +142,6 @@ fun MainScreen(
         selectedLocationButton,
         onLocationButtonChanged,
         onReloadButtonChanged,
-        initLocationSize,
-        onInitLocationChanged,
-        screenCoordinate,
         onSplashScreenShowAble,
         onLoadingChanged,
         onCurrentMapChanged,

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -12,6 +12,7 @@ import com.example.domain.util.Resource
 import com.example.presentation.model.LocationTrackingButton
 import com.example.presentation.util.MainConstants.FAIL_TO_LOAD_DATA
 import com.example.presentation.util.MainConstants.GREAT_STORE
+import com.example.presentation.util.MainConstants.INITIALIZE_ABLE
 import com.example.presentation.util.MainConstants.KIND_STORE
 import com.example.presentation.util.MainConstants.SAFE_STORE
 import com.example.presentation.util.UiState
@@ -30,7 +31,7 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     private val _ableToShowSplashScreen = MutableStateFlow(true)
     val ableToShowSplashScreen: StateFlow<Boolean> = _ableToShowSplashScreen
 
-    var ableToShowInitialMarker = true
+    var storeInitializeState = INITIALIZE_ABLE
 
     private val filterSet = mutableSetOf<String>()
 

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -31,8 +31,6 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
     private val _ableToShowSplashScreen = MutableStateFlow(true)
     val ableToShowSplashScreen: StateFlow<Boolean> = _ableToShowSplashScreen
 
-    var storeInitializeState = INITIALIZE_ABLE
-
     private val filterSet = mutableSetOf<String>()
 
     private val _storeDetailModelData =
@@ -45,6 +43,9 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
 
     val flattenedStoreDetailList: MutableStateFlow<List<StoreDetail>> =
         MutableStateFlow(emptyList())
+
+    private val _storeInitializeState = MutableStateFlow(INITIALIZE_ABLE)
+    val storeInitializeState: StateFlow<Int> get() = _storeInitializeState
 
     private val _isInitialize = MutableStateFlow(true)
     val isInitialize get() = _isInitialize
@@ -137,6 +138,10 @@ class MapViewModel @Inject constructor(private val getStoreDetailUseCase: GetSto
                 showMoreStore(0)
             }
         }
+    }
+
+    fun updateStoreInitializeState(state: Int) {
+        _storeInitializeState.value = state
     }
 
     fun updateIsInitialize() {

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -52,7 +52,6 @@ import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberFusedLocationSource
 import kotlinx.coroutines.launch
 
-
 @SuppressLint("StateFlowValueCalledInComposition", "CoroutineCreationDuringComposition")
 @ExperimentalNaverMapApi
 @Composable
@@ -79,6 +78,8 @@ fun NaverMapScreen(
     clickedStoreLocation: Coordinate,
     onShowMoreCountChanged: (ShowMoreCount) -> Unit,
     onReloadOrShowMoreChanged: (Boolean) -> Unit,
+    isReloadButtonClicked: Boolean,
+    onGetNewScreenCoordinateChanged: (Boolean) -> Unit,
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
@@ -105,7 +106,6 @@ fun NaverMapScreen(
                 selectedLocationButton.mode,
                 onCurrentMapChanged
             )
-            GetScreenCoordinate(this, onScreenChanged)
         },
         locationSource = rememberFusedLocationSource(),
         properties = MapProperties(
@@ -184,6 +184,11 @@ fun NaverMapScreen(
             if (selectedLocationButton == LocationTrackingButton.FOLLOW || selectedLocationButton == LocationTrackingButton.FACE) {
                 onLocationButtonChanged(LocationTrackingButton.NO_FOLLOW)
             }
+        }
+
+        if (isReloadButtonClicked) {
+            GetScreenCoordinate(cameraPositionState, onScreenChanged)
+            onGetNewScreenCoordinateChanged(true)
         }
     }
 
@@ -275,8 +280,10 @@ fun InitializeMarker(
         onReloadButtonChanged(true)
     }
 
-    if (isMapGestured && selectedLocationButtonMode != LocationTrackingMode.None && selectedLocationButtonMode != LocationTrackingMode.NoFollow) {
-        TurnOffLocationButton(onLocationButtonChanged)
+    if (isMapGestured) {
+        if (selectedLocationButtonMode != LocationTrackingMode.None && selectedLocationButtonMode != LocationTrackingMode.NoFollow) {
+            TurnOffLocationButton(onLocationButtonChanged)
+        }
         onMapGestureChanged(false)
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -161,7 +161,7 @@ fun NaverMapScreen(
                 is UiState.Success -> {
                     val isInitializationLocation =
                         mapViewModel.isLocationPermissionGranted.value.not()
-                                || (mapViewModel.storeInitializeState == INITIALIZE_DONE)
+                                || (mapViewModel.storeInitializeState.value == INITIALIZE_DONE)
                     if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value && state.data.isNotEmpty()) {
                         onSplashScreenShowAble(false)
                     }
@@ -264,17 +264,19 @@ fun InitializeMarker(
 ) {
     val (initialLocationSetting, onInitialLocationSetting) = remember { mutableStateOf(false) }
     LaunchedEffect(cameraPositionState.isMoving) {
-        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState == INITIALIZE_ABLE
+        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_ABLE
             && cameraPositionState.position.target == LatLng(37.5666102, 126.9783881)
         ) {
             initializeStoreInDefaultLocation(
                 onScreenChanged, mainViewModel, onInitialLocationSetting
             )
         }
-        if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.LOCATION && cameraPositionState.isMoving && mainViewModel.storeInitializeState == INITIALIZE_DEFAULT_DONE) {
+        if (cameraPositionState.cameraUpdateReason == CameraUpdateReason.LOCATION && cameraPositionState.isMoving
+            && mainViewModel.storeInitializeState.value == INITIALIZE_DEFAULT_DONE
+        ) {
             checkInitialMoveByLocation(mainViewModel)
         }
-        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState == INITIALIZE_MOVE_ONCE) {
+        if (cameraPositionState.isMoving.not() && mainViewModel.storeInitializeState.value == INITIALIZE_MOVE_ONCE) {
             initializeStoreInCurrentLocation(mainViewModel, onInitialLocationSetting)
         }
     }
@@ -310,19 +312,19 @@ private fun initializeStoreInDefaultLocation(
             ),
         )
     )
-    mainViewModel.storeInitializeState = INITIALIZE_DEFAULT_DONE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_DEFAULT_DONE)
     onInitialLocationSetting(true)
 }
 
 private fun checkInitialMoveByLocation(mainViewModel: MapViewModel) {
-    mainViewModel.storeInitializeState = INITIALIZE_MOVE_ONCE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_MOVE_ONCE)
 }
 
 private fun initializeStoreInCurrentLocation(
     mainViewModel: MapViewModel,
     onInitialLocationSetting: (Boolean) -> Unit
 ) {
-    mainViewModel.storeInitializeState = INITIALIZE_DONE
+    mainViewModel.updateStoreInitializeState(INITIALIZE_DONE)
     onInitialLocationSetting(true)
 }
 

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -7,7 +7,6 @@ object MainConstants {
     const val BOTTOM_SHEET_STORE_DETAIL_IMG_SIZE = 133
     const val BOTTOM_SHEET_STORE_LIST_IMG_SIZE = 69
     const val DEFAULT_MARGIN = 16
-    const val LOCATION_SIZE = 8
     const val UN_MARKER = -1L
     const val DETAIL_BOTTOM_SHEET_HEIGHT = 530
     const val LIST_BOTTOM_SHEET_COLLAPSE_HEIGHT = 38
@@ -16,6 +15,10 @@ object MainConstants {
     const val HANDLE_HEIGHT = 14
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200
+    const val INITIALIZE_ABLE = -1
+    const val INITIALIZE_MOVE_ONCE = 0
+    const val INITIALIZE_DONE = 1
+    const val INITIALIZE_DEFAULT_DONE = 2
 
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"

--- a/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
+++ b/presentation/src/main/java/com/example/presentation/util/MainConstants.kt
@@ -16,9 +16,9 @@ object MainConstants {
     const val DIM_ANIMATION_MILLIS = 200
     const val BOTTOM_SHEET_ANIMATION_MILLIS = 200
     const val INITIALIZE_ABLE = -1
-    const val INITIALIZE_MOVE_ONCE = 0
-    const val INITIALIZE_DONE = 1
-    const val INITIALIZE_DEFAULT_DONE = 2
+    const val INITIALIZE_DEFAULT_DONE = 0
+    const val INITIALIZE_MOVE_ONCE = 1
+    const val INITIALIZE_DONE = 2
 
     const val KIND_STORE = "착한가격업소"
     const val GREAT_STORE = "모범음식점"


### PR DESCRIPTION
## ⭐️ Issue Number

- #67 

## 🚩 Summary
- 제스처 로직 리팩토링
- 화면 좌표 갱신 로직 리팩토링

## 🛠️ Technical Concerns

### 제스처 로직 리팩토링
기존 로직은 originCoordinate와 newCoordinate 변수를 두어 두 변수가 다르면 제스처가 된 것으로 판단하였습니다.
이를 위해서 지도의 카메라가 변동하면 항상 newCoordinate을 갱신해야했기 때문에 지나친 Recomposition이 발생했었습니다.

NaverMap의 `CameraPositionState`에서 카메라의 움직임 여부를 알 수 있는 `isMoving`과 지도 카메라 움직임의 이유를 알 수 있는 `CameraUpdateReason`을 지원하고 있기 때문에 이를 활용하면 보다 좋은 코드를 짤 수 있을 것이라 판단하였습니다.

따라서 `LaunchedEffect(cameraPositionState.isMoving)` 조건일 때, 
1. `INITIALIZE_DONE`인 상태로 이미 초기 현위치 로직이 끝난 상태이면서 
2. `isMoving`으로 카메라가 움직이고 있고, 
3. 카메라 움직임의 이유가 `CameraUpdateReason.GESTURE` 일 때

이를 **맵이 제스처 되고 있는 경우**라고 판단하였습니다. 이때 `ReloadOrShowMoreButton()`이 보일 수 있도록 구현하였습니다. 

### 화면 좌표 갱신 로직 리팩토링
기존에는 화면 좌표 또한 NaverMap에 존재하고 있어 map이 Recompostion이 될 때마다 화면 좌표를 갱신하고 있었습니다.
이는 매우 비효율적이라고 판단하여 재검색 버튼이 눌렸을 때(`isReloadButtonClicked`이 true일 때)만 `GetScreenCoordinate()`을 호출해 화면 좌표가 갱신되도록 하였습니다.

하지만, 이때 화면과 맞지 않는 마커가 지도에 찍히는 문제가 발생하였습니다.
이는 `GetScreenCoordinate()`으로 화면 좌표를 갱신하는 코드보다 network 통신하는 코드가 빨라 제대로 갱신된 좌표를 이용하지 않아서 발생한 문제였습니다.

따라서 화면 좌표가 갱신된 후에 network 통신을 하기 위해서 추가적으로 `isScreenCoordinateChanged` 변수를 만들어 주었습니다.

## 🙂 To Reviwer
- 이제 더 이상 제스처 할 동안 맵이 Recomposition 되지 않습니다...!!! 할렐루야
- 기분탓인지 모르겠지만, 앱이 좀 더 빠릿빠릿해진 것 같아용 😄 

## 📋 To Do
