### PR TITLE
hotfix Splash Animation 오류 해결

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/splash/SplashAnimation.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/splash/SplashAnimation.kt
@@ -29,11 +29,11 @@ fun SplashAnimation() {
     val imgIdx = remember {
         Animatable(initialValue = 0f)
     }
-    val currentImg = loadingImgList[imgIdx.value.toInt()]
+    val currentImg = loadingImgList[imgIdx.value.toInt() % loadingImgList.size]
 
     LaunchedEffect(Unit) {
         imgIdx.animateTo(
-            targetValue = (loadingImgList.lastIndex + 1).toFloat(),
+            targetValue = loadingImgList.size.toFloat(),
             animationSpec = infiniteRepeatable(
                 animation = tween(durationMillis = 5000, easing = LinearEasing),
                 repeatMode = RepeatMode.Restart


### PR DESCRIPTION
## 🚩 Summary

![image](https://github.com/Korea-Certified-Store/AOS/assets/74500793/ee154ad2-2d31-4ac7-ac6b-74a4a89dc9a0)

스플래시 idx가 최대 4이어야하는데 5가 나오면서 생기는 문제
animation의 value가 0.0 부터 5.0까지 실수로 증가하면서 5.0이 되면 idx가 최댓값4를 초과해버린다.
기기마다 value가 증가하는 것이 달라 5.0이 되지 않으면 해당 오류가 일어나지 않았다.
따라서 5로 나눈 나머지를 idx로 하여 해당 오류가 일어나지 않도록 수정하였다.
