### PR TITLE
검색어 초기화

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
@@ -1,19 +1,12 @@
 package com.example.presentation.ui
 
-import android.app.Activity
-import android.widget.Toast
-import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.map.location.LocationPermissionRequest
 import com.example.presentation.ui.onboarding.OnboardingScreen
 import com.example.presentation.ui.splash.SplashScreen
-import com.example.presentation.util.MapScreenType
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import kotlinx.coroutines.delay
 
@@ -62,28 +55,5 @@ fun InitScreen(
             mapViewModel.updateSplashState()
         }
         LocationPermissionRequest(mapViewModel)
-    }
-
-    PressBack(mapViewModel, navController)
-}
-
-@Composable
-fun PressBack(mapViewModel: MapViewModel, navController: NavHostController) {
-    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    var backPressedTime = 0L
-
-    BackHandler {
-        if (mapScreenType == MapScreenType.SEARCH) {
-            navController.popBackStack()
-            mapViewModel.updateMapScreenType(MapScreenType.MAIN)
-        } else {
-            if (System.currentTimeMillis() - backPressedTime <= 2000L) {
-                (context as Activity).finish()
-            } else {
-                Toast.makeText(context, "한 번 더 누르면 앱이 종료됩니다.", Toast.LENGTH_SHORT).show()
-            }
-            backPressedTime = System.currentTimeMillis()
-        }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
@@ -1,9 +1,12 @@
 package com.example.presentation.ui
 
+import android.app.Activity
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.presentation.ui.map.MapViewModel
@@ -61,12 +64,26 @@ fun InitScreen(
         LocationPermissionRequest(mapViewModel)
     }
 
+    PressBack(mapViewModel, navController)
+}
+
+@Composable
+fun PressBack(mapViewModel: MapViewModel, navController: NavHostController) {
     val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    var backPressedTime = 0L
 
     BackHandler {
         if (mapScreenType == MapScreenType.SEARCH) {
             navController.popBackStack()
             mapViewModel.updateMapScreenType(MapScreenType.MAIN)
+        } else {
+            if (System.currentTimeMillis() - backPressedTime <= 2000L) {
+                (context as Activity).finish()
+            } else {
+                Toast.makeText(context, "한 번 더 누르면 앱이 종료됩니다.", Toast.LENGTH_SHORT).show()
+            }
+            backPressedTime = System.currentTimeMillis()
         }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
@@ -1,12 +1,16 @@
 package com.example.presentation.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.map.location.LocationPermissionRequest
 import com.example.presentation.ui.onboarding.OnboardingScreen
 import com.example.presentation.ui.splash.SplashScreen
+import com.example.presentation.util.MapScreenType
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import kotlinx.coroutines.delay
 
@@ -55,5 +59,14 @@ fun InitScreen(
             mapViewModel.updateSplashState()
         }
         LocationPermissionRequest(mapViewModel)
+    }
+
+    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
+
+    BackHandler {
+        if (mapScreenType == MapScreenType.SEARCH) {
+            navController.popBackStack()
+            mapViewModel.updateMapScreenType(MapScreenType.MAIN)
+        }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -6,9 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.animation.EnterTransition
@@ -33,14 +31,10 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private var backPressedTime: Long = 0
-
     private val mapViewModel by viewModels<MapViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
         setContent {
 
@@ -104,17 +98,6 @@ class MainActivity : ComponentActivity() {
         if (isLocationPermissionGranted(this)) {
             lifecycleScope.launch {
                 mapViewModel.updateLocationPermission(true)
-            }
-        }
-    }
-
-    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
-        override fun handleOnBackPressed() {
-            if (System.currentTimeMillis() - backPressedTime <= 2000) {
-                finish()
-            } else {
-                backPressedTime = System.currentTimeMillis()
-                Toast.makeText(this@MainActivity, "한 번 더 누르면 종료합니다.", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -26,7 +26,6 @@ import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
 import com.example.presentation.ui.search.StoreSearchComponent
 import com.example.presentation.util.MainConstants
 import com.example.presentation.util.MainConstants.UN_MARKER
-import com.example.presentation.util.MapScreenType
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 
 @ExperimentalNaverMapApi
@@ -124,14 +123,6 @@ fun MainScreen(
 
     val (isSearchComponentClicked, onSearchComponentChanged) = remember { mutableStateOf(false) }
 
-    val (mapScreenType, onMapScreenTypeChanged) = remember { mutableStateOf(MapScreenType.MAIN) }
-
-    if (searchText == null) {
-        onMapScreenTypeChanged(MapScreenType.MAIN)
-    } else {
-        onMapScreenTypeChanged(MapScreenType.SEARCH)
-    }
-
     NaverMapScreen(
         isMarkerClicked,
         onBottomSheetChanged,
@@ -159,7 +150,6 @@ fun MainScreen(
         isSearchComponentClicked,
         onSearchComponentChanged,
         mapViewModel,
-        mapScreenType,
         navController
     )
 

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -105,8 +105,6 @@ fun MainScreen(
 
     val (isLoading, onLoadingChanged) = remember { mutableStateOf(false) }
 
-    val (isFilteredMarker, onFilteredMarkerChanged) = remember { mutableStateOf(false) }
-
     val (errorToastMsg, onErrorToastChanged) = remember { mutableStateOf("") }
 
     val (isListItemClicked, onListItemChanged) = remember { mutableStateOf(false) }
@@ -123,6 +121,12 @@ fun MainScreen(
 
     val (isSearchComponentClicked, onSearchComponentChanged) = remember { mutableStateOf(false) }
 
+    val (isSearchTerminationButtonClicked, onSearchTerminationButtonChanged) = remember {
+        mutableStateOf(
+            false
+        )
+    }
+
     NaverMapScreen(
         isMarkerClicked,
         onBottomSheetChanged,
@@ -137,8 +141,6 @@ fun MainScreen(
         onSplashScreenShowAble,
         onLoadingChanged,
         onCurrentMapChanged,
-        isFilteredMarker,
-        onFilteredMarkerChanged,
         onErrorToastChanged,
         isListItemClicked,
         onListItemChanged,
@@ -149,6 +151,8 @@ fun MainScreen(
         onGetNewScreenCoordinateChanged,
         isSearchComponentClicked,
         onSearchComponentChanged,
+        isSearchTerminationButtonClicked,
+        onSearchTerminationButtonChanged,
         mapViewModel,
         navController
     )
@@ -168,7 +172,11 @@ fun MainScreen(
         )
     }
 
-    StoreSearchComponent(navController, searchText, onSearchComponentChanged)
+    StoreSearchComponent(
+        searchText,
+        onSearchComponentChanged,
+        onSearchTerminationButtonChanged
+    )
 
     FilterComponent(
         isKindFilterClicked,
@@ -223,8 +231,8 @@ fun MainScreen(
         onCallDialogChanged(false)
     }
 
-    if (isReloadButtonClicked && isScreenCoordinateChanged) {
-        onFilteredMarkerChanged(false)
+    if ((isReloadButtonClicked && isScreenCoordinateChanged)) {
+        mapViewModel.updateIsFilteredMarker(false)
         onErrorToastChanged("")
         mapViewModel.getStoreDetail(
             nwLong = screenCoordinate.northWest.longitude,

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -77,6 +77,12 @@ class MapViewModel @Inject constructor(
     private val _mapScreenType = MutableStateFlow(MapScreenType.MAIN)
     val mapScreenType: StateFlow<MapScreenType> = _mapScreenType
 
+    private val _isSearchTerminated = MutableStateFlow(false)
+    val isSearchTerminated: StateFlow<Boolean> = _isSearchTerminated
+
+    private val _isFilteredMarker = MutableStateFlow(false)
+    val isFilteredMarker: StateFlow<Boolean> = _isFilteredMarker
+
     fun showMoreStore(count: Int) {
         val newItem: List<StoreDetail> = when (val uiState = _storeDetailModelData.value) {
             is UiState.Success -> uiState.data.getOrNull(count) ?: emptyList()
@@ -232,5 +238,13 @@ class MapViewModel @Inject constructor(
 
     fun updateMapScreenType(type: MapScreenType) {
         _mapScreenType.value = type
+    }
+
+    fun updateIsSearchTerminated(isTerminated: Boolean) {
+        _isSearchTerminated.value = isTerminated
+    }
+
+    fun updateIsFilteredMarker(isFilteredMarker: Boolean) {
+        _isFilteredMarker.value = isFilteredMarker
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -17,6 +17,7 @@ import com.example.presentation.util.MainConstants.GREAT_STORE
 import com.example.presentation.util.MainConstants.INITIALIZE_ABLE
 import com.example.presentation.util.MainConstants.KIND_STORE
 import com.example.presentation.util.MainConstants.SAFE_STORE
+import com.example.presentation.util.MapScreenType
 import com.example.presentation.util.UiState
 import com.naver.maps.geometry.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -72,6 +73,9 @@ class MapViewModel @Inject constructor(
 
     private val _mapZoomLevel = MutableStateFlow(0.0)
     val mapZoomLevel: StateFlow<Double> = _mapZoomLevel
+
+    private val _mapScreenType = MutableStateFlow(MapScreenType.MAIN)
+    val mapScreenType: StateFlow<MapScreenType> = _mapScreenType
 
     fun showMoreStore(count: Int) {
         val newItem: List<StoreDetail> = when (val uiState = _storeDetailModelData.value) {
@@ -224,5 +228,9 @@ class MapViewModel @Inject constructor(
 
     fun updateMapZoomLevel(zoom: Double) {
         _mapZoomLevel.value = zoom
+    }
+
+    fun updateMapScreenType(type: MapScreenType) {
+        _mapScreenType.value = type
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -89,7 +89,6 @@ fun NaverMapScreen(
     isSearchComponentClicked: Boolean,
     onSearchComponentChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
-    mapScreenType: MapScreenType,
     navController: NavController
 ) {
     val cameraPositionState = rememberCameraPositionState {}
@@ -135,6 +134,7 @@ fun NaverMapScreen(
     ) {
 
         val storeDetailData by mapViewModel.storeDetailModelData.collectAsStateWithLifecycle()
+        val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
 
         if (mapScreenType == MapScreenType.MAIN) {
             LaunchedEffect(key1 = storeDetailData) {

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -76,8 +76,6 @@ fun NaverMapScreen(
     onSplashScreenShowAble: (Boolean) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
     onCurrentMapChanged: (Boolean) -> Unit,
-    isFilteredMarker: Boolean,
-    onFilteredMarkerChanged: (Boolean) -> Unit,
     onErrorToastChanged: (String) -> Unit,
     isListItemClicked: Boolean,
     onListItemChanged: (Boolean) -> Unit,
@@ -88,12 +86,17 @@ fun NaverMapScreen(
     onGetNewScreenCoordinateChanged: (Boolean) -> Unit,
     isSearchComponentClicked: Boolean,
     onSearchComponentChanged: (Boolean) -> Unit,
+    isSearchTerminationButtonClicked: Boolean,
+    onSearchTerminationButtonChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
     navController: NavController
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
     val scope = rememberCoroutineScope()
+
+    val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
+    val mapZoomLevel by mapViewModel.mapZoomLevel.collectAsStateWithLifecycle()
 
     NaverMap(
         modifier = Modifier.fillMaxSize(),
@@ -138,7 +141,6 @@ fun NaverMapScreen(
 
         if (mapScreenType == MapScreenType.MAIN) {
             LaunchedEffect(key1 = storeDetailData) {
-
                 when (val state = storeDetailData) {
                     is UiState.Loading -> {
                         if (mapViewModel.ableToShowSplashScreen.value.not()) {
@@ -153,7 +155,7 @@ fun NaverMapScreen(
                         if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value) {
                             onSplashScreenShowAble(false)
                         }
-                        onFilteredMarkerChanged(true)
+                        mapViewModel.updateIsFilteredMarker(true)
                         onLoadingChanged(false)
                         onCurrentMapChanged(false)
                         onShowMoreCountChanged(ShowMoreCount(0, state.data.size))
@@ -173,11 +175,9 @@ fun NaverMapScreen(
                 Dp(35F).roundToPx()
             }
             val searchStore by mapViewModel.searchStoreModelData.collectAsStateWithLifecycle()
-            val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
             val searchBounds by mapViewModel.searchBounds.collectAsStateWithLifecycle()
-            val mapZoomLevel by mapViewModel.mapZoomLevel.collectAsStateWithLifecycle()
-            LaunchedEffect(key1 = searchStore) {
 
+            LaunchedEffect(key1 = searchStore) {
                 val bounds = LatLngBounds(
                     searchBounds.first,
                     searchBounds.second
@@ -189,7 +189,7 @@ fun NaverMapScreen(
                     }
 
                     is UiState.Success -> {
-                        onFilteredMarkerChanged(true)
+                        mapViewModel.updateIsFilteredMarker(true)
                         onCurrentMapChanged(false)
                         onReloadOrShowMoreChanged(false)
 
@@ -212,25 +212,14 @@ fun NaverMapScreen(
                     }
 
                     is UiState.Failure -> {
-                        val position = CameraPosition(
-                            LatLng(
-                                mapCenterCoordinate.latitude,
-                                mapCenterCoordinate.longitude
-                            ), mapZoomLevel
-                        )
-
-                        cameraPositionState.animate(
-                            CameraUpdate.toCameraPosition(position),
-                            animation = CameraAnimation.None,
-                            durationMs = 500
-                        )
-
+                        movePrevCamera(cameraPositionState, mapCenterCoordinate, mapZoomLevel)
                         showErrorToastMsg(state, onReloadOrShowMoreChanged, onErrorToastChanged)
                     }
                 }
             }
         }
 
+        val isFilteredMarker by mapViewModel.isFilteredMarker.collectAsStateWithLifecycle()
         if (isFilteredMarker) {
             FilteredMarkers(
                 mapViewModel,
@@ -280,6 +269,17 @@ fun NaverMapScreen(
         onLocationButtonChanged,
         mapViewModel,
         currentSummaryInfoHeight
+    )
+
+    CheckSearchTerminationButtonClicked(
+        isSearchTerminationButtonClicked,
+        mapViewModel,
+        cameraPositionState,
+        navController,
+        onSearchTerminationButtonChanged,
+        onReloadButtonChanged,
+        mapCenterCoordinate,
+        mapZoomLevel
     )
 }
 
@@ -472,4 +472,65 @@ fun GetScreenCoordinate(
             )
         )
     }
+}
+
+@Composable
+private fun CheckSearchTerminationButtonClicked(
+    isSearchTerminationButtonClicked: Boolean,
+    mapViewModel: MapViewModel,
+    cameraPositionState: CameraPositionState,
+    navController: NavController,
+    onSearchTerminationButtonChanged: (Boolean) -> Unit,
+    onReloadButtonChanged: (Boolean) -> Unit,
+    mapCenterCoordinate: Coordinate,
+    mapZoomLevel: Double
+) {
+    if (isSearchTerminationButtonClicked) {
+        mapViewModel.updateMapCenterCoordinate(
+            Coordinate(
+                cameraPositionState.position.target.latitude,
+                cameraPositionState.position.target.longitude,
+            )
+        )
+        mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
+        mapViewModel.updateMapScreenType(MapScreenType.MAIN)
+        navController.navigate(Screen.Main.route) {
+            popUpTo(navController.graph.id) {
+                inclusive = true
+            }
+        }
+        onSearchTerminationButtonChanged(false)
+        mapViewModel.updateIsSearchTerminated(true)
+    }
+
+    val isSearchTerminated by mapViewModel.isSearchTerminated.collectAsStateWithLifecycle()
+
+    LaunchedEffect(key1 = isSearchTerminated) {
+        if (isSearchTerminated) {
+            movePrevCamera(cameraPositionState, mapCenterCoordinate, mapZoomLevel)
+            onReloadButtonChanged(true)
+            mapViewModel.updateIsSearchTerminated(false)
+        }
+    }
+}
+
+@OptIn(ExperimentalNaverMapApi::class)
+private suspend fun movePrevCamera(
+    cameraPositionState: CameraPositionState,
+    mapCenterCoordinate: Coordinate,
+    mapZoomLevel: Double
+) {
+
+    val position = CameraPosition(
+        LatLng(
+            mapCenterCoordinate.latitude,
+            mapCenterCoordinate.longitude
+        ), mapZoomLevel
+    )
+
+    cameraPositionState.animate(
+        CameraUpdate.toCameraPosition(position),
+        animation = CameraAnimation.None,
+        durationMs = 500
+    )
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import com.example.domain.model.map.ShowMoreCount
 import com.example.domain.util.ErrorMessage.ERROR_MESSAGE_STORE_IS_EMPTY
 import com.example.presentation.mapper.toUiModel
@@ -88,8 +88,10 @@ fun NaverMapScreen(
     onSearchComponentChanged: (Boolean) -> Unit,
     isSearchTerminationButtonClicked: Boolean,
     onSearchTerminationButtonChanged: (Boolean) -> Unit,
+    isBackPressed: Boolean,
+    onBackPressedChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
-    navController: NavController
+    navController: NavHostController
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
@@ -260,6 +262,17 @@ fun NaverMapScreen(
             mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
             navController.navigate(Screen.Search.route)
             onSearchComponentChanged(false)
+        }
+        if (isBackPressed) {
+            mapViewModel.updateMapCenterCoordinate(
+                Coordinate(
+                    cameraPositionState.position.target.latitude,
+                    cameraPositionState.position.target.longitude,
+                )
+            )
+            mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
+            onBackPressedChanged(false)
+            navController.popBackStack()
         }
     }
 
@@ -479,7 +492,7 @@ private fun CheckSearchTerminationButtonClicked(
     isSearchTerminationButtonClicked: Boolean,
     mapViewModel: MapViewModel,
     cameraPositionState: CameraPositionState,
-    navController: NavController,
+    navController: NavHostController,
     onSearchTerminationButtonChanged: (Boolean) -> Unit,
     onReloadButtonChanged: (Boolean) -> Unit,
     mapCenterCoordinate: Coordinate,

--- a/presentation/src/main/java/com/example/presentation/ui/map/SearchOnCurrentMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/SearchOnCurrentMapScreen.kt
@@ -1,0 +1,97 @@
+package com.example.presentation.ui.map
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.presentation.R
+import com.example.presentation.ui.theme.Black
+import com.example.presentation.ui.theme.Blue
+import com.example.presentation.ui.theme.White
+import com.example.presentation.util.MainConstants.BOTTOM_SHEET_DEFAULT_PADDING
+import com.example.presentation.util.MainConstants.BOTTOM_SHEET_HEIGHT_OFF
+import com.example.presentation.util.MainConstants.SEARCH_ON_CURRENT_MAP_BUTTON_DEFAULT_PADDING
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchOnCurrentMapButton(
+    isMarkerClicked: Boolean,
+    onSearchOnCurrentMapButtonChanged: (Boolean) -> Unit,
+    bottomSheetHeight: Dp,
+    onMarkerChanged: (Long) -> Unit,
+    onBottomSheetChanged: (Boolean) -> Unit
+) {
+    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth()
+                .padding(
+                    bottom = setSearchOnCurrentMapBottomPadding(
+                        isMarkerClicked,
+                        bottomSheetHeight
+                    )
+                ),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    onSearchOnCurrentMapButtonChanged(true)
+                    onMarkerChanged(-1)
+                    onBottomSheetChanged(false)
+                },
+                modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = White,
+                    contentColor = Black
+                ),
+                shape = RoundedCornerShape(30.dp),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.search),
+                    tint = Blue,
+                    contentDescription = "Search",
+                    modifier = Modifier.size(13.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = stringResource(R.string.search_on_current_map),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Normal
+                )
+            }
+        }
+    }
+}
+
+fun setSearchOnCurrentMapBottomPadding(isMarkerClicked: Boolean, bottomSheetHeight: Dp): Dp {
+    return if (isMarkerClicked) bottomSheetHeight + (SEARCH_ON_CURRENT_MAP_BUTTON_DEFAULT_PADDING + BOTTOM_SHEET_DEFAULT_PADDING).dp
+    else (BOTTOM_SHEET_HEIGHT_OFF + SEARCH_ON_CURRENT_MAP_BUTTON_DEFAULT_PADDING).dp
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
@@ -97,7 +97,7 @@ fun StoreSummaryBottomSheet(
                     modifier = Modifier
                         .width(32.dp)
                         .height(3.dp)
-                        .background(Color.LightGray)
+                        .background(White)
                 )
             }
         },
@@ -131,13 +131,16 @@ fun StoreSummaryInfo(
         ) {
             StoreTitle(
                 storeInfo.displayName,
-                storeInfo.primaryTypeDisplayName ?: "상점",
+                storeInfo.primaryTypeDisplayName ?: "",
                 "storeTitle",
                 maxWidth
             )
             Chips(storeInfo.certificationName, "chips", maxWidth)
             StoreOpeningTime(storeInfo.operatingType, storeInfo.timeDescription, "storeOpeningTime")
-            if (storeInfo.phoneNumber != null) StoreCallButton(onCallDialogChanged, "storeCallButton")
+            if (storeInfo.phoneNumber != null) StoreCallButton(
+                onCallDialogChanged,
+                "storeCallButton"
+            )
             StoreImageCard("storeImage", storeInfo.localPhotos)
         }
     }

--- a/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
@@ -1,0 +1,333 @@
+package com.example.presentation.ui.map
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+import com.example.presentation.R
+import com.example.presentation.model.StoreDetail
+import com.example.presentation.model.StoreType
+import com.example.presentation.ui.theme.DarkGray
+import com.example.presentation.ui.theme.LightBlue
+import com.example.presentation.ui.theme.LightGray
+import com.example.presentation.ui.theme.LightYellow
+import com.example.presentation.ui.theme.MediumBlue
+import com.example.presentation.ui.theme.MediumGray
+import com.example.presentation.ui.theme.Pink
+import com.example.presentation.ui.theme.Red
+import com.example.presentation.ui.theme.White
+import com.example.presentation.util.MainConstants.BOTTOM_SHEET_DEFAULT_PADDING
+import com.example.presentation.util.MainConstants.BOTTOM_SHEET_HEIGHT_OFF
+import com.example.presentation.util.MainConstants.BOTTOM_SHEET_STORE_IMG_SIZE
+import com.example.presentation.util.MainConstants.DEFAULT_MARIN
+import com.skydoves.landscapist.coil.CoilImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StoreSummaryBottomSheet(
+    isMarkerClicked: Boolean,
+    clickedStoreInfo: StoreDetail,
+    onCallDialogChanged: (Boolean) -> Unit,
+    bottomSheetHeight: Dp,
+    onHeightChanged: (Dp) -> Unit
+) {
+    BottomSheetScaffold(
+        sheetContent = {
+            Column {
+                StoreSummaryInfo(
+                    clickedStoreInfo,
+                    onCallDialogChanged,
+                    onHeightChanged,
+                    bottomSheetHeight
+                )
+            }
+        },
+        sheetPeekHeight = if (isMarkerClicked) bottomSheetHeight + BOTTOM_SHEET_DEFAULT_PADDING.dp else BOTTOM_SHEET_HEIGHT_OFF.dp,
+        sheetContainerColor = White,
+        sheetShape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp),
+        sheetShadowElevation = 5.dp,
+        sheetDragHandle = {
+            Column {
+                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(
+                    modifier = Modifier
+                        .width(32.dp)
+                        .height(3.dp)
+                        .background(Color.LightGray)
+                )
+            }
+        },
+        sheetSwipeEnabled = false
+    ) {
+    }
+}
+
+@Composable
+fun StoreSummaryInfo(
+    storeInfo: StoreDetail,
+    onCallDialogChanged: (Boolean) -> Unit,
+    onHeightChanged: (Dp) -> Unit,
+    currentHeight: Dp
+) {
+    val density = LocalDensity.current
+    BoxWithConstraints {
+        ConstraintLayout(
+            modifier = Modifier
+                .padding(horizontal = DEFAULT_MARIN.dp, vertical = 13.dp)
+                .fillMaxWidth(1f)
+                .wrapContentHeight()
+                .onSizeChanged { size ->
+                    val newHeight = with(density) { size.height.toDp() }
+
+                    if (newHeight != currentHeight) {
+                        onHeightChanged(newHeight)
+                    }
+                },
+            constraintSet = bottomSheetConstraints()
+        ) {
+            StoreTitle(
+                storeInfo.displayName,
+                storeInfo.primaryTypeDisplayName ?: "상점",
+                "storeTitle",
+                maxWidth
+            )
+            Chips(storeInfo.certificationName, "chips", maxWidth)
+            StoreOpeningTime(storeInfo.operatingType, storeInfo.timeDescription, "storeOpeningTime")
+            if (storeInfo.phoneNumber != null) StoreCallButton(onCallDialogChanged, "storeCallButton")
+            StoreImageCard("storeImage", storeInfo.localPhotos)
+        }
+    }
+}
+
+fun bottomSheetConstraints(): ConstraintSet {
+    return ConstraintSet {
+        val storeTitle = createRefFor("storeTitle")
+        val chips = createRefFor("chips")
+        val storeOpeningTime = createRefFor("storeOpeningTime")
+        val storeCallButton = createRefFor("storeCallButton")
+        val storeImage = createRefFor("storeImage")
+
+        constrain(storeTitle) {
+            top.linkTo(parent.top)
+            linkTo(start = parent.start, end = storeImage.start, endMargin = 12.dp, bias = 0F)
+        }
+        constrain(chips) {
+            top.linkTo(storeTitle.bottom, 4.dp)
+            linkTo(start = parent.start, end = storeImage.start, endMargin = 12.dp, bias = 0F)
+        }
+        constrain(storeOpeningTime) {
+            start.linkTo(parent.start)
+            top.linkTo(chips.bottom, 3.dp)
+        }
+        constrain(storeCallButton) {
+            start.linkTo(parent.start)
+            top.linkTo(storeOpeningTime.bottom, 5.dp)
+            bottom.linkTo(parent.bottom)
+        }
+        constrain(storeImage) {
+            end.linkTo(parent.end)
+            top.linkTo(parent.top)
+        }
+    }
+}
+
+@Composable
+fun StoreTitle(storeName: String, storeType: String, id: String, maxWidth: Dp) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .layoutId(id)
+            .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp)
+    ) {
+        Text(
+            text = storeName,
+            color = MediumBlue,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.layoutId(id),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = storeType,
+            color = MediumGray,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Normal
+        )
+    }
+}
+
+@Composable
+fun Chip(
+    storeType: StoreType
+) {
+    Column {
+        Surface(
+            color = when (storeType) {
+                StoreType.KIND -> Pink
+                StoreType.GREAT -> LightYellow
+                StoreType.SAFE -> LightBlue
+            },
+            shape = RoundedCornerShape(30.dp)
+        ) {
+            Text(
+                text = stringResource(storeType.storeTypeName),
+                color = MediumGray,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Thin,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+            )
+        }
+        Spacer(modifier = Modifier.padding(2.dp))
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun Chips(
+    elements: List<StoreType>,
+    id: String,
+    maxWidth: Dp
+) {
+    FlowRow(
+        modifier = Modifier
+            .layoutId(id)
+            .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp),
+    ) {
+        elements.forEach { item ->
+            Chip(storeType = item)
+            Spacer(modifier = Modifier.padding(4.dp))
+        }
+    }
+}
+
+@Composable
+fun StoreOpeningTime(
+    operatingType: String,
+    timeDescription: String,
+    id: String
+) {
+    Row(modifier = Modifier.layoutId(id)) {
+        Text(
+            text = operatingType,
+            Modifier.alignByBaseline(),
+            color = Red,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Normal
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            text = timeDescription,
+            Modifier.alignByBaseline(),
+            color = MediumGray,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Normal
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StoreCallButton(
+    onCallDialogChanged: (Boolean) -> Unit,
+    id: String
+) {
+    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+        Button(
+            onClick = {
+                onCallDialogChanged(true)
+            },
+            modifier = Modifier
+                .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
+                .layoutId(id),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 1.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = White),
+            shape = RoundedCornerShape(3.dp),
+            border = BorderStroke(1.dp, Color.LightGray)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.call),
+                tint = DarkGray,
+                contentDescription = "Call",
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun StoreImageCard(id: String, localPhotos: List<String>) {
+    Card(
+        modifier = Modifier
+            .size(BOTTOM_SHEET_STORE_IMG_SIZE.dp)
+            .layoutId(id),
+        shape = RoundedCornerShape(6.dp),
+        border = BorderStroke(0.3.dp, LightGray)
+    ) {
+        StoreImage(localPhotos = localPhotos)
+    }
+}
+
+@Composable
+fun StoreImage(localPhotos: List<String>) {
+    if (localPhotos.isNotEmpty()) {
+        CoilImage(
+            imageModel = localPhotos.first(),
+            contentScale = ContentScale.Crop,
+            placeHolder = painterResource(R.drawable.empty_store_img),
+            error = painterResource(R.drawable.empty_store_img)
+        )
+    } else {
+        Image(
+            painter = painterResource(R.drawable.empty_store_img),
+            contentDescription = "Store Image",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(1f)
+        )
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/StoreSummaryScreen.kt
@@ -3,6 +3,7 @@ package com.example.presentation.ui.map
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
@@ -59,6 +61,7 @@ import com.example.presentation.ui.theme.MediumBlue
 import com.example.presentation.ui.theme.MediumGray
 import com.example.presentation.ui.theme.Pink
 import com.example.presentation.ui.theme.Red
+import com.example.presentation.ui.theme.SemiLightGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.BOTTOM_SHEET_DEFAULT_PADDING
 import com.example.presentation.util.MainConstants.BOTTOM_SHEET_HEIGHT_OFF
@@ -117,7 +120,7 @@ fun StoreSummaryInfo(
     BoxWithConstraints {
         ConstraintLayout(
             modifier = Modifier
-                .padding(horizontal = DEFAULT_MARIN.dp, vertical = 13.dp)
+                .padding(horizontal = DEFAULT_MARIN.dp, vertical = 12.dp)
                 .fillMaxWidth(1f)
                 .wrapContentHeight()
                 .onSizeChanged { size ->
@@ -131,11 +134,15 @@ fun StoreSummaryInfo(
         ) {
             StoreTitle(
                 storeInfo.displayName,
-                storeInfo.primaryTypeDisplayName ?: "",
                 "storeTitle",
                 maxWidth
             )
-            Chips(storeInfo.certificationName, "chips", maxWidth)
+            StorePrimaryTypeText(
+                storeInfo.primaryTypeDisplayName ?: "",
+                "storePrimaryType",
+                maxWidth
+            )
+            StoreTypeChips(storeInfo.certificationName, "chips", maxWidth)
             StoreOpeningTime(storeInfo.operatingType, storeInfo.timeDescription, "storeOpeningTime")
             if (storeInfo.phoneNumber != null) StoreCallButton(
                 onCallDialogChanged,
@@ -149,6 +156,7 @@ fun StoreSummaryInfo(
 fun bottomSheetConstraints(): ConstraintSet {
     return ConstraintSet {
         val storeTitle = createRefFor("storeTitle")
+        val storePrimaryType = createRefFor("storePrimaryType")
         val chips = createRefFor("chips")
         val storeOpeningTime = createRefFor("storeOpeningTime")
         val storeCallButton = createRefFor("storeCallButton")
@@ -156,19 +164,23 @@ fun bottomSheetConstraints(): ConstraintSet {
 
         constrain(storeTitle) {
             top.linkTo(parent.top)
-            linkTo(start = parent.start, end = storeImage.start, endMargin = 12.dp, bias = 0F)
+            linkTo(start = parent.start, end = storeImage.start, endMargin = 8.dp, bias = 0F)
+        }
+        constrain(storePrimaryType) {
+            top.linkTo(storeTitle.bottom, 5.dp)
+            linkTo(start = parent.start, end = storeImage.start, endMargin = 8.dp, bias = 0F)
         }
         constrain(chips) {
-            top.linkTo(storeTitle.bottom, 4.dp)
-            linkTo(start = parent.start, end = storeImage.start, endMargin = 12.dp, bias = 0F)
+            top.linkTo(storePrimaryType.bottom, 5.dp)
+            linkTo(start = parent.start, end = storeImage.start, endMargin = 8.dp, bias = 0F)
         }
         constrain(storeOpeningTime) {
             start.linkTo(parent.start)
-            top.linkTo(chips.bottom, 3.dp)
+            top.linkTo(chips.bottom, 11.dp)
         }
         constrain(storeCallButton) {
             start.linkTo(parent.start)
-            top.linkTo(storeOpeningTime.bottom, 5.dp)
+            top.linkTo(storeOpeningTime.bottom, 21.dp)
             bottom.linkTo(parent.bottom)
         }
         constrain(storeImage) {
@@ -179,60 +191,59 @@ fun bottomSheetConstraints(): ConstraintSet {
 }
 
 @Composable
-fun StoreTitle(storeName: String, storeType: String, id: String, maxWidth: Dp) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+fun StoreTitle(storeName: String, id: String, maxWidth: Dp) {
+    Text(
+        text = storeName,
+        color = MediumBlue,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier
             .layoutId(id)
-            .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp)
-    ) {
-        Text(
-            text = storeName,
-            color = MediumBlue,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.layoutId(id),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = storeType,
-            color = MediumGray,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Normal
-        )
-    }
+            .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp),
+    )
 }
 
 @Composable
-fun Chip(
+fun StorePrimaryTypeText(storeType: String, id: String, maxWidth: Dp) {
+    Text(
+        text = storeType,
+        color = MediumGray,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Normal,
+        modifier = Modifier
+            .layoutId(id)
+            .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp),
+    )
+}
+
+@Composable
+fun StoreTypeChip(
     storeType: StoreType
 ) {
-    Column {
-        Surface(
-            color = when (storeType) {
-                StoreType.KIND -> Pink
-                StoreType.GREAT -> LightYellow
-                StoreType.SAFE -> LightBlue
-            },
-            shape = RoundedCornerShape(30.dp)
-        ) {
-            Text(
-                text = stringResource(storeType.storeTypeName),
-                color = MediumGray,
-                fontSize = 10.sp,
-                fontWeight = FontWeight.Thin,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
-            )
-        }
-        Spacer(modifier = Modifier.padding(2.dp))
+    Surface(
+        color = when (storeType) {
+            StoreType.KIND -> Pink
+            StoreType.GREAT -> LightYellow
+            StoreType.SAFE -> LightBlue
+        },
+        shape = RoundedCornerShape(30.dp),
+        modifier = Modifier.padding(end = 4.dp)
+    ) {
+        Text(
+            text = stringResource(storeType.storeTypeName),
+            color = MediumGray,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.Normal,
+            modifier = Modifier.padding(horizontal = 7.dp, vertical = 4.dp)
+        )
     }
 }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun Chips(
+fun StoreTypeChips(
     elements: List<StoreType>,
     id: String,
     maxWidth: Dp
@@ -243,8 +254,7 @@ fun Chips(
             .width(maxWidth - BOTTOM_SHEET_STORE_IMG_SIZE.dp - (DEFAULT_MARIN * 2).dp),
     ) {
         elements.forEach { item ->
-            Chip(storeType = item)
-            Spacer(modifier = Modifier.padding(4.dp))
+            StoreTypeChip(storeType = item)
         }
     }
 }
@@ -255,23 +265,37 @@ fun StoreOpeningTime(
     timeDescription: String,
     id: String
 ) {
-    Row(modifier = Modifier.layoutId(id)) {
+    Row(
+        modifier = Modifier.layoutId(id),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         Text(
             text = operatingType,
             Modifier.alignByBaseline(),
             color = Red,
-            fontSize = 15.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Normal
         )
-        Spacer(modifier = Modifier.width(10.dp))
+        Spacer(modifier = Modifier.width(4.dp))
+        StoreOpeningTimeCircle()
+        Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = timeDescription,
             Modifier.alignByBaseline(),
             color = MediumGray,
-            fontSize = 13.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Normal
         )
     }
+}
+
+@Composable
+fun StoreOpeningTimeCircle() {
+    Box(
+        modifier = Modifier
+            .size(2.dp)
+            .background(color = LightGray, shape = CircleShape),
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -288,7 +312,7 @@ fun StoreCallButton(
             modifier = Modifier
                 .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
                 .layoutId(id),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 1.dp),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 0.dp),
             colors = ButtonDefaults.buttonColors(containerColor = White),
             shape = RoundedCornerShape(3.dp),
             border = BorderStroke(1.dp, Color.LightGray)
@@ -297,7 +321,7 @@ fun StoreCallButton(
                 imageVector = ImageVector.vectorResource(id = R.drawable.call),
                 tint = DarkGray,
                 contentDescription = "Call",
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(29.dp)
             )
         }
     }
@@ -310,7 +334,7 @@ fun StoreImageCard(id: String, localPhotos: List<String>) {
             .size(BOTTOM_SHEET_STORE_IMG_SIZE.dp)
             .layoutId(id),
         shape = RoundedCornerShape(6.dp),
-        border = BorderStroke(0.3.dp, LightGray)
+        border = BorderStroke(0.3.dp, SemiLightGray)
     ) {
         StoreImage(localPhotos = localPhotos)
     }

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -192,6 +192,7 @@ fun SearchTextField(
             if (searchText.isNotBlank()) {
                 insertSearchWord(searchText, searchViewModel)
 
+                mapViewModel.updateIsFilteredMarker(false)
                 mapViewModel.searchStore(
                     mapCenterCoordinate.longitude,
                     mapCenterCoordinate.latitude,

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -1,5 +1,6 @@
 package com.example.presentation.ui.search
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -37,7 +38,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -65,6 +65,7 @@ import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
 import com.example.presentation.util.MainConstants.SEARCH_KEY
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_HEIGHT
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_TOP_PADDING
+import com.example.presentation.util.MapScreenType
 
 @Composable
 fun SearchScreen(
@@ -87,6 +88,11 @@ fun SearchScreen(
         if (isDeleteAllDialogVisible) {
             DeleteAllDialog(onDeleteAllDialogVisibleChanged)
         }
+    }
+
+    BackHandler {
+        mapViewModel.updateMapScreenType(MapScreenType.MAIN)
+        navController.popBackStack()
     }
 }
 
@@ -132,6 +138,7 @@ fun SearchTextField(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
+    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
 
     BasicTextField(
         value = searchText,
@@ -194,7 +201,16 @@ fun SearchTextField(
                     key = SEARCH_KEY,
                     value = searchText
                 )
-                navController.navigate(Screen.Main.route)
+
+                mapViewModel.updateMapScreenType(MapScreenType.SEARCH)
+                if (mapScreenType == MapScreenType.MAIN) {
+                    navController.navigate(Screen.Main.route)
+                } else {
+                    navController.navigate(Screen.Main.route) {
+                        popUpTo(Screen.Main.route) { inclusive = true }
+                    }
+                }
+
                 keyboardController?.hide()
             }
         })

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -92,6 +92,7 @@ fun SearchScreen(
 
     BackHandler {
         mapViewModel.updateMapScreenType(MapScreenType.MAIN)
+        mapViewModel.updateIsSearchTerminated(true)
         navController.popBackStack()
     }
 }
@@ -111,7 +112,7 @@ private fun SearchAppBar(
                 vertical = SEARCH_TEXT_FIELD_TOP_PADDING.dp
             )
     ) {
-        BackArrow(navController)
+        BackArrow(navController, mapViewModel)
         SearchTextField(navController, mapViewModel)
     }
 }
@@ -228,13 +229,14 @@ fun insertSearchWord(keyword: String, viewModel: SearchViewModel) {
 }
 
 @Composable
-private fun BackArrow(navController: NavHostController) {
+private fun BackArrow(navController: NavHostController, mapViewModel: MapViewModel) {
     Image(
         imageVector = ImageVector.vectorResource(id = R.drawable.arrow),
         contentDescription = "Arrow",
         modifier = Modifier
             .size(18.dp)
             .clickable {
+                mapViewModel.updateIsSearchTerminated(true)
                 navController.popBackStack()
             }
     )

--- a/presentation/src/main/java/com/example/presentation/ui/search/StoreSearchComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/StoreSearchComponent.kt
@@ -26,9 +26,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import com.example.presentation.R
-import com.example.presentation.ui.navigation.Screen
 import com.example.presentation.ui.theme.MediumGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
@@ -37,9 +35,9 @@ import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_TOP_PADDING
 
 @Composable
 fun StoreSearchComponent(
-    navController: NavController,
     searchText: String?,
-    onSearchComponentChanged: (Boolean) -> Unit
+    onSearchComponentChanged: (Boolean) -> Unit,
+    onSearchTerminationButtonChanged: (Boolean) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -65,10 +63,13 @@ fun StoreSearchComponent(
     ) {
         if (searchText.isNullOrBlank()) {
             SearchPlaceHolderText(stringResource(R.string.search_placeholder_text), MediumGray)
-            SearchSuffixImage(R.drawable.search, navController)
+            SearchSuffixImage(R.drawable.search)
         } else {
             SearchPlaceHolderText(searchText, Black)
-            SearchSuffixImage(R.drawable.delete, navController)
+            SearchSuffixImage(
+                R.drawable.delete,
+                onSearchTerminationButtonChanged
+            )
         }
     }
 }
@@ -86,7 +87,10 @@ fun SearchPlaceHolderText(text: String, textColor: Color) {
 }
 
 @Composable
-fun SearchSuffixImage(@DrawableRes image: Int, navController: NavController) {
+fun SearchSuffixImage(
+    @DrawableRes image: Int,
+    onSearchTerminationButtonChanged: (Boolean) -> Unit = {}
+) {
     Image(
         imageVector = ImageVector.vectorResource(id = image),
         contentDescription = "Delete",
@@ -94,11 +98,7 @@ fun SearchSuffixImage(@DrawableRes image: Int, navController: NavController) {
             .padding(end = DEFAULT_MARGIN.dp)
             .size(16.dp)
             .clickable(enabled = image == R.drawable.delete) {
-                navController.navigate(Screen.Main.route) {
-                    popUpTo(navController.graph.id) {
-                        inclusive = true
-                    }
-                }
+                onSearchTerminationButtonChanged(true)
             }
     )
 }


### PR DESCRIPTION
## ⭐️ Issue Number

- #86 

## 🚩 Summary
- 뒤로가기 로직 ios에 맞춰서 구현
- x 버튼 클릭시 검색 초기화
  - 이때 검색 창의 지도만큼 재검색을 함
- SearchScreen에서 뒤로가기 클릭시 검색 초기화
  - 이때 검색 창의 지도만큼 재검색을 함


https://github.com/Korea-Certified-Store/AOS/assets/74500793/4ac90815-88cd-456f-a323-962ae8a5cd84




## 🛠️ Technical Concerns

### 뒤로가기 로직
|화면|조작|기능|
|---|---|---|
|MainScreen -> SearchScreen| 안드로이드 시스템 뒤로가기 & SearchScreen 뒤로가기 버튼 | 검색 종료|
|MainScreen -> SearchScreen -> 검색결과 MainScreen| 안드로이드 시스템 뒤로가기 | SearchScreen으로 이동 |
|MainScreen -> SearchScreen -> 검색결과 MainScreen -> (안드로이드 시스템 뒤로가기를 눌러서) SearchScreen | 안드로이드 시스템 뒤로가기 & SearchScreen 뒤로가기 버튼 | 검색 종료|
|MainScreen -> SearchScreen -> 검색결과 MainScreen -> (SearchComponent를 눌러서) SearchScreen| SearchScreen 뒤로가기 버튼 | 이전 검색 결과 MainScreen으로 이동|
|MainScreen -> SearchScreen -> 검색결과 MainScreen -> (SearchComponent를 눌러서) SearchScreen| 안드로이드 시스템 뒤로가기 버튼 | 검색 종료 |

- SearchScreen을 초기MainScreen에서 왔으면 `MapScreenType.MAIN`이고, 검색결과MainScreen에서 왔으면 `MapScreenType.SEARCH`이다.
- 안드로이드 뒤로가기는 Stack을 pop한다.
- SearchScreen에서 Done을 클릭하면,
만일 `MapScreenType.MAIN`에서 왔으면 Stack에 검색결과MainScreen을 쌓고,
만일 `MapScreenType.SEARCH`에서 왔으면 Stack에 이전 검색결과MainScreen까지 pop하고, 새로운 검색결과 MainScreen이 쌓인다.
```kotlin
if (mapScreenType == MapScreenType.MAIN) {
  navController.navigate(Screen.Main.route)
} else {
  navController.navigate(Screen.Main.route) {
    popUpTo(Screen.Main.route) { inclusive = true }
  }
}
```


- 검색결과 MainScreen에서 SearchComponent를 클릭하면 Stack을 pop한다.
- 검색이 종료가 되면 검색결과Screen에 맞춰서 재검색을 한다.

## 🙂 To Reviwer

- 지금 검색후 또 검색을 할때 SearchComponent의 SearchText가 제대로 변하지 않는 에러가 있습니다. 이것을 SearchText를 ViewModel로 옮겨서 SearchScreen의 TextField에서도 남아있게 구현하면 좋을 것 같아요
- 검색 종료시, 현재 위치를 계속 Follow하고 있습니다. camera를 움직여줬는데도 noFollow가 안되고 있는건 왜그럴까요..? 그리고 검색시 camera 이동했을 때 noFollow가 되긴하지만, 현재 위치 버튼의 색깔이 파란색으로 남아있습니다.

## 📋 To Do
