### PR TITLE
현위치에서 키워드로 재검색, 검색 시 필터 초기화

### DIFF
--- a/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/InitScreen.kt
@@ -16,7 +16,6 @@ fun InitScreen(
     onCallStoreChanged: (String) -> Unit,
     onSplashScreenShowAble: (Boolean) -> Unit,
     navController: NavHostController,
-    searchText: String?,
     isFirstRun: Boolean,
     isOnboardingScreenShowAble: Boolean,
     onOnboardingScreenShowAble: (Boolean) -> Unit,
@@ -29,7 +28,6 @@ fun InitScreen(
         onCallStoreChanged,
         onSplashScreenShowAble,
         navController,
-        searchText,
         mapViewModel
     )
 

--- a/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainActivity.kt
@@ -24,7 +24,6 @@ import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.navigation.Screen
 import com.example.presentation.ui.search.SearchScreen
 import com.example.presentation.ui.theme.Android_KCSTheme
-import com.example.presentation.util.MainConstants.SEARCH_KEY
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -64,16 +63,10 @@ class MainActivity : ComponentActivity() {
                     composable(
                         route = Screen.Main.route
                     ) {
-                        val searchText = remember {
-                            navController.previousBackStackEntry?.savedStateHandle?.get<String>(
-                                SEARCH_KEY
-                            )
-                        }
                         InitScreen(
                             onCallStoreChanged,
                             onSplashScreenShowAble,
                             navController,
-                            searchText,
                             isFirstRun,
                             isOnboardingScreenShowAble,
                             onOnboardingScreenShowAble,

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.domain.model.map.ShowMoreCount
@@ -22,6 +23,7 @@ import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.map.NaverMapScreen
 import com.example.presentation.ui.map.call.StoreCallDialog
 import com.example.presentation.ui.map.filter.FilterComponent
+import com.example.presentation.ui.map.filter.FilterViewModel
 import com.example.presentation.ui.map.list.StoreListBottomSheet
 import com.example.presentation.ui.map.reload.ReloadOrShowMoreButton
 import com.example.presentation.ui.map.summary.DimScreen
@@ -41,7 +43,8 @@ fun MainScreen(
     onSplashScreenShowAble: (Boolean) -> Unit,
     navController: NavHostController,
     searchText: String?,
-    mapViewModel: MapViewModel
+    mapViewModel: MapViewModel,
+    filterViewModel : FilterViewModel = hiltViewModel()
 ) {
     val (clickedStoreInfo, onStoreInfoChanged) = remember {
         mutableStateOf(
@@ -207,7 +210,6 @@ fun MainScreen(
     )
 
     FilterComponent(
-        mapViewModel,
         onFilterStateChanged
     )
 
@@ -255,7 +257,7 @@ fun MainScreen(
 
     val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
     if (isReSearchButtonClicked && isScreenCoordinateChanged) {
-        mapViewModel.updateIsFilteredMarker(false)
+        filterViewModel.updateIsFilteredMarker(false)
         mapViewModel.searchStore(
             mapCenterCoordinate.longitude,
             mapCenterCoordinate.latitude,
@@ -266,7 +268,7 @@ fun MainScreen(
     }
 
     if ((isReloadButtonClicked && isScreenCoordinateChanged)) {
-        mapViewModel.updateIsFilteredMarker(false)
+        filterViewModel.updateIsFilteredMarker(false)
         onErrorToastChanged("")
         mapViewModel.getStoreDetail(
             nwLong = screenCoordinate.northWest.longitude,

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -28,7 +28,7 @@ import com.example.presentation.ui.map.list.StoreListBottomSheet
 import com.example.presentation.ui.map.reload.ReloadOrShowMoreButton
 import com.example.presentation.ui.map.summary.DimScreen
 import com.example.presentation.ui.map.summary.StoreSummaryBottomSheet
-import com.example.presentation.ui.search.ReSearchComponent
+import com.example.presentation.ui.search.ReSearchButtonComponent
 import com.example.presentation.ui.search.StoreSearchComponent
 import com.example.presentation.util.MainConstants
 import com.example.presentation.util.MainConstants.SEARCH_KEY
@@ -42,7 +42,6 @@ fun MainScreen(
     onCallStoreChanged: (String) -> Unit,
     onSplashScreenShowAble: (Boolean) -> Unit,
     navController: NavHostController,
-    searchText: String?,
     mapViewModel: MapViewModel,
     filterViewModel : FilterViewModel = hiltViewModel()
 ) {
@@ -178,7 +177,7 @@ fun MainScreen(
 
     if (isReloadOrShowMoreShowAble) {
         if (isSearchTextExist) {
-            ReSearchComponent(
+            ReSearchButtonComponent(
                 isMarkerClicked,
                 currentSummaryInfoHeight,
                 isMapGestured,

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -206,7 +206,8 @@ fun MainScreen(
     StoreSearchComponent(
         searchText,
         onSearchComponentChanged,
-        onSearchTerminationButtonChanged
+        onSearchTerminationButtonChanged,
+        mapViewModel
     )
 
     FilterComponent(

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -1,7 +1,6 @@
 package com.example.presentation.ui
 
 import android.app.Activity
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
@@ -72,10 +71,6 @@ fun MainScreen(
         mutableStateOf(false)
     }
 
-    val (isKindFilterClicked, onKindFilterChanged) = remember { mutableStateOf(false) }
-    val (isGreatFilterClicked, onGreatFilterChanged) = remember { mutableStateOf(false) }
-    val (isSafeFilterClicked, onSafeFilterChanged) = remember { mutableStateOf(false) }
-
     val (screenCoordinate, onScreenChanged) = remember {
         mutableStateOf(
             ScreenCoordinate(
@@ -111,8 +106,6 @@ fun MainScreen(
     }
 
     val (isLoading, onLoadingChanged) = remember { mutableStateOf(false) }
-
-    val (isFilteredMarker, onFilteredMarkerChanged) = remember { mutableStateOf(false) }
 
     val (errorToastMsg, onErrorToastChanged) = remember { mutableStateOf("") }
 
@@ -177,8 +170,6 @@ fun MainScreen(
         onBackPressedChanged,
         mapViewModel,
         navController,
-        isFilteredMarker,
-        onFilteredMarkerChanged,
         isReSearchButtonClicked
     )
 
@@ -216,12 +207,6 @@ fun MainScreen(
     )
 
     FilterComponent(
-        isKindFilterClicked,
-        onKindFilterChanged,
-        isGreatFilterClicked,
-        onGreatFilterChanged,
-        isSafeFilterClicked,
-        onSafeFilterChanged,
         mapViewModel,
         onFilterStateChanged
     )
@@ -270,7 +255,6 @@ fun MainScreen(
 
     val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
     if (isReSearchButtonClicked && isScreenCoordinateChanged) {
-        Log.d("테스트", "키워드 재검색 눌리고있음?")
         mapViewModel.updateIsFilteredMarker(false)
         mapViewModel.searchStore(
             mapCenterCoordinate.longitude,
@@ -284,7 +268,6 @@ fun MainScreen(
     if ((isReloadButtonClicked && isScreenCoordinateChanged)) {
         mapViewModel.updateIsFilteredMarker(false)
         onErrorToastChanged("")
-        onFilteredMarkerChanged(false)
         mapViewModel.getStoreDetail(
             nwLong = screenCoordinate.northWest.longitude,
             nwLat = screenCoordinate.northWest.latitude,
@@ -321,7 +304,7 @@ fun MainScreen(
 @Composable
 fun PressBack(
     mapViewModel: MapViewModel,
-    onBackPressedChanged: (Boolean) -> Unit
+    onBackPressedChanged: (Boolean) -> Unit,
 ) {
     val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -329,6 +312,7 @@ fun PressBack(
 
     BackHandler {
         if (mapScreenType == MapScreenType.SEARCH) {
+            mapViewModel.updateIsSearchTerminated(true)
             onBackPressedChanged(true)
             mapViewModel.updateMapScreenType(MapScreenType.MAIN)
         } else {

--- a/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/MainScreen.kt
@@ -139,6 +139,14 @@ fun MainScreen(
     }
     val (isBackPressed, onBackPressedChanged) = remember { mutableStateOf(false) }
 
+    val isSearchTextExist = navController.previousBackStackEntry?.savedStateHandle?.contains(
+        SEARCH_KEY
+    ) ?: false
+
+    val searchText = navController.previousBackStackEntry?.savedStateHandle?.get<String>(
+        SEARCH_KEY
+    )
+
     NaverMapScreen(
         isMarkerClicked,
         onBottomSheetChanged,
@@ -175,10 +183,7 @@ fun MainScreen(
     )
 
     if (isReloadOrShowMoreShowAble) {
-        val searchText = navController.previousBackStackEntry?.savedStateHandle?.contains(
-            SEARCH_KEY
-        ) ?: false
-        if (searchText) {
+        if (isSearchTextExist) {
             ReSearchComponent(
                 isMarkerClicked,
                 currentSummaryInfoHeight,

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -110,6 +110,10 @@ class MapViewModel @Inject constructor(
         }
     }
 
+    fun initializeFilterSet() {
+        filterSet.clear()
+    }
+
     fun setLocationTrackingMode(): LocationTrackingButton {
         return if (isLocationPermissionGranted.value) {
             LocationTrackingButton.FOLLOW

--- a/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/MapViewModel.kt
@@ -13,10 +13,7 @@ import com.example.domain.util.Resource
 import com.example.presentation.model.Coordinate
 import com.example.presentation.model.LocationTrackingButton
 import com.example.presentation.util.MainConstants.FAIL_TO_LOAD_DATA
-import com.example.presentation.util.MainConstants.GREAT_STORE
 import com.example.presentation.util.MainConstants.INITIALIZE_ABLE
-import com.example.presentation.util.MainConstants.KIND_STORE
-import com.example.presentation.util.MainConstants.SAFE_STORE
 import com.example.presentation.util.MapScreenType
 import com.example.presentation.util.UiState
 import com.naver.maps.geometry.LatLng
@@ -37,8 +34,6 @@ class MapViewModel @Inject constructor(
 
     private val _ableToShowSplashScreen = MutableStateFlow(true)
     val ableToShowSplashScreen: StateFlow<Boolean> = _ableToShowSplashScreen
-
-    private val filterSet = mutableSetOf<String>()
 
     private val _storeDetailModelData =
         MutableStateFlow<UiState<List<List<StoreDetail>>>>(UiState.Loading)
@@ -80,9 +75,6 @@ class MapViewModel @Inject constructor(
     private val _isSearchTerminated = MutableStateFlow(false)
     val isSearchTerminated: StateFlow<Boolean> = _isSearchTerminated
 
-    private val _isFilteredMarker = MutableStateFlow(false)
-    val isFilteredMarker: StateFlow<Boolean> = _isFilteredMarker
-
     fun showMoreStore(count: Int) {
         val newItem: List<StoreDetail> = when (val uiState = _storeDetailModelData.value) {
             is UiState.Success -> uiState.data.getOrNull(count) ?: emptyList()
@@ -95,23 +87,6 @@ class MapViewModel @Inject constructor(
 
     fun updateSplashState() {
         _ableToShowSplashScreen.value = false
-    }
-
-    fun getFilterSet(): Set<String> {
-        return if (filterSet.isEmpty()) setOf(SAFE_STORE, GREAT_STORE, KIND_STORE)
-        else filterSet.toSet()
-    }
-
-    fun updateFilterSet(certificationName: String, isClicked: Boolean) {
-        if (isClicked) {
-            filterSet.add(certificationName)
-        } else {
-            filterSet.remove(certificationName)
-        }
-    }
-
-    fun initializeFilterSet() {
-        filterSet.clear()
     }
 
     fun setLocationTrackingMode(): LocationTrackingButton {
@@ -246,9 +221,5 @@ class MapViewModel @Inject constructor(
 
     fun updateIsSearchTerminated(isTerminated: Boolean) {
         _isSearchTerminated.value = isTerminated
-    }
-
-    fun updateIsFilteredMarker(isFilteredMarker: Boolean) {
-        _isFilteredMarker.value = isFilteredMarker
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -91,7 +91,10 @@ fun NaverMapScreen(
     isBackPressed: Boolean,
     onBackPressedChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
-    navController: NavHostController
+    navController: NavHostController,
+    isFilteredMarker: Boolean,
+    onFilteredMarkerChanged: (Boolean) -> Unit,
+    isReSearchButtonClicked: Boolean
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
@@ -247,6 +250,15 @@ fun NaverMapScreen(
             if (selectedLocationButton == LocationTrackingButton.FOLLOW || selectedLocationButton == LocationTrackingButton.FACE) {
                 onLocationButtonChanged(LocationTrackingButton.NO_FOLLOW)
             }
+        }
+        if (isReSearchButtonClicked) {
+            mapViewModel.updateMapCenterCoordinate(
+                Coordinate(
+                    cameraPositionState.position.target.latitude,
+                    cameraPositionState.position.target.longitude
+                )
+            )
+            onGetNewScreenCoordinateChanged(true)
         }
         if (isReloadButtonClicked) {
             GetScreenCoordinate(cameraPositionState, onScreenChanged)

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.example.domain.model.map.ShowMoreCount
@@ -28,6 +29,7 @@ import com.example.presentation.model.LocationTrackingButton
 import com.example.presentation.model.ScreenCoordinate
 import com.example.presentation.model.StoreDetail
 import com.example.presentation.model.StoreType
+import com.example.presentation.ui.map.filter.FilterViewModel
 import com.example.presentation.ui.map.location.CurrentLocationComponent
 import com.example.presentation.ui.map.marker.StoreMarker
 import com.example.presentation.ui.map.reload.setReloadButtonBottomPadding
@@ -92,9 +94,8 @@ fun NaverMapScreen(
     onBackPressedChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
     navController: NavHostController,
-    isFilteredMarker: Boolean,
-    onFilteredMarkerChanged: (Boolean) -> Unit,
-    isReSearchButtonClicked: Boolean
+    isReSearchButtonClicked: Boolean,
+    filterViewModel:FilterViewModel = hiltViewModel()
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
@@ -225,6 +226,7 @@ fun NaverMapScreen(
         }
 
         val isFilteredMarker by mapViewModel.isFilteredMarker.collectAsStateWithLifecycle()
+
         if (isFilteredMarker) {
             FilteredMarkers(
                 mapViewModel,
@@ -273,6 +275,8 @@ fun NaverMapScreen(
             )
             mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
             navController.navigate(Screen.Search.route)
+            filterViewModel.updateAllFilterUnClicked()
+            mapViewModel.initializeFilterSet()
             onSearchComponentChanged(false)
         }
         if (isBackPressed) {
@@ -508,7 +512,8 @@ private fun CheckSearchTerminationButtonClicked(
     onSearchTerminationButtonChanged: (Boolean) -> Unit,
     onReloadButtonChanged: (Boolean) -> Unit,
     mapCenterCoordinate: Coordinate,
-    mapZoomLevel: Double
+    mapZoomLevel: Double,
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
     if (isSearchTerminationButtonClicked) {
         mapViewModel.updateMapCenterCoordinate(
@@ -532,6 +537,8 @@ private fun CheckSearchTerminationButtonClicked(
 
     LaunchedEffect(key1 = isSearchTerminated) {
         if (isSearchTerminated) {
+            filterViewModel.updateAllFilterUnClicked()
+            mapViewModel.initializeFilterSet()
             movePrevCamera(cameraPositionState, mapCenterCoordinate, mapZoomLevel)
             onReloadButtonChanged(true)
             mapViewModel.updateIsSearchTerminated(false)

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -95,7 +95,7 @@ fun NaverMapScreen(
     mapViewModel: MapViewModel,
     navController: NavHostController,
     isReSearchButtonClicked: Boolean,
-    filterViewModel:FilterViewModel = hiltViewModel()
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
     val cameraPositionState = rememberCameraPositionState {}
 
@@ -161,7 +161,7 @@ fun NaverMapScreen(
                         if (isInitializationLocation && mapViewModel.ableToShowSplashScreen.value) {
                             onSplashScreenShowAble(false)
                         }
-                        mapViewModel.updateIsFilteredMarker(true)
+                        filterViewModel.updateIsFilteredMarker(true)
                         onLoadingChanged(false)
                         onCurrentMapChanged(false)
                         onShowMoreCountChanged(ShowMoreCount(0, state.data.size))
@@ -195,7 +195,7 @@ fun NaverMapScreen(
                     }
 
                     is UiState.Success -> {
-                        mapViewModel.updateIsFilteredMarker(true)
+                        filterViewModel.updateIsFilteredMarker(true)
                         onCurrentMapChanged(false)
                         onReloadOrShowMoreChanged(false)
 
@@ -225,7 +225,7 @@ fun NaverMapScreen(
             }
         }
 
-        val isFilteredMarker by mapViewModel.isFilteredMarker.collectAsStateWithLifecycle()
+        val isFilteredMarker by filterViewModel.isFilteredMarker.collectAsStateWithLifecycle()
 
         if (isFilteredMarker) {
             FilteredMarkers(
@@ -276,7 +276,6 @@ fun NaverMapScreen(
             mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
             navController.navigate(Screen.Search.route)
             filterViewModel.updateAllFilterUnClicked()
-            mapViewModel.initializeFilterSet()
             onSearchComponentChanged(false)
         }
         if (isBackPressed) {
@@ -336,13 +335,14 @@ fun FilteredMarkers(
     onStoreInfoChanged: (StoreDetail) -> Unit,
     clickedMarkerId: Long,
     onMarkerChanged: (Long) -> Unit,
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
     val storeDetailData by mapViewModel.flattenedStoreDetailList.collectAsStateWithLifecycle()
     storeDetailData.filter { info ->
-        mapViewModel.getFilterSet().intersect(info.certificationName.toSet()).isNotEmpty()
+        filterViewModel.getFilterSet().intersect(info.certificationName.toSet()).isNotEmpty()
     }.forEach { info ->
         val storeType =
-            when (mapViewModel.getFilterSet().intersect(info.certificationName.toSet())
+            when (filterViewModel.getFilterSet().intersect(info.certificationName.toSet())
                 .last()) {
                 KIND_STORE -> StoreType.KIND
                 GREAT_STORE -> StoreType.GREAT
@@ -538,7 +538,6 @@ private fun CheckSearchTerminationButtonClicked(
     LaunchedEffect(key1 = isSearchTerminated) {
         if (isSearchTerminated) {
             filterViewModel.updateAllFilterUnClicked()
-            mapViewModel.initializeFilterSet()
             movePrevCamera(cameraPositionState, mapCenterCoordinate, mapZoomLevel)
             onReloadButtonChanged(true)
             mapViewModel.updateIsSearchTerminated(false)

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -191,10 +191,11 @@ fun NaverMapScreen(
 
                 when (val state = searchStore) {
                     is UiState.Loading -> {
-                        // Todo : 검색 시 로딩 뷰 구현
+                        onLoadingChanged(true)
                     }
 
                     is UiState.Success -> {
+                        onLoadingChanged(false)
                         filterViewModel.updateIsFilteredMarker(true)
                         onCurrentMapChanged(false)
                         onReloadOrShowMoreChanged(false)

--- a/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/NaverMapScreen.kt
@@ -275,6 +275,7 @@ fun NaverMapScreen(
                 )
             )
             mapViewModel.updateMapZoomLevel(cameraPositionState.position.zoom)
+            mapViewModel.updateMapScreenType(MapScreenType.MAIN)
             navController.navigate(Screen.Search.route)
             filterViewModel.updateAllFilterUnClicked()
             onSearchComponentChanged(false)

--- a/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterComponent.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.model.StoreType
-import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.Blue
 import com.example.presentation.ui.theme.White
@@ -42,7 +41,6 @@ import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_TOP_PADDING
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun FilterComponent(
-    mapViewModel: MapViewModel,
     onFilterStateChanged: (Boolean) -> Unit,
     filterViewModel: FilterViewModel = hiltViewModel()
 ) {
@@ -63,19 +61,16 @@ fun FilterComponent(
         FilterButton(
             storeType = StoreType.KIND,
             isKindClicked.value,
-            mapViewModel,
             onFilterStateChanged
         )
         FilterButton(
             storeType = StoreType.GREAT,
             isGreatClicked.value,
-            mapViewModel,
             onFilterStateChanged
         )
         FilterButton(
             storeType = StoreType.SAFE,
             isSafeClicked.value,
-            mapViewModel,
             onFilterStateChanged
         )
     }
@@ -86,7 +81,6 @@ fun FilterComponent(
 fun FilterButton(
     storeType: StoreType,
     isFilterClicked: Boolean,
-    mapViewModel: MapViewModel,
     onFilterStateChanged: (Boolean) -> Unit,
     filterViewModel: FilterViewModel = hiltViewModel(),
 ) {
@@ -94,7 +88,7 @@ fun FilterButton(
     CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
         Button(
             onClick = {
-                mapViewModel.updateFilterSet(certificationName, isFilterClicked.not())
+                filterViewModel.updateFilterSet(certificationName, isFilterClicked.not())
                 when (storeType) {
                     StoreType.KIND -> filterViewModel.updateKindFilterClicked()
                     StoreType.SAFE -> filterViewModel.updateSafeFilterClicked()

--- a/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterComponent.kt
@@ -1,5 +1,6 @@
 package com.example.presentation.ui.map.filter
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.model.StoreType
 import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.Black
@@ -36,43 +39,42 @@ import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_HEIGHT
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_TOP_PADDING
 
+@SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun FilterComponent(
-    isKindFilterClicked: Boolean,
-    onKindFilterChanged: (Boolean) -> Unit,
-    isGreatFilterClicked: Boolean,
-    onGreatFilterChanged: (Boolean) -> Unit,
-    isSafeFilterClicked: Boolean,
-    onSafeFilterChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
     onFilterStateChanged: (Boolean) -> Unit,
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
 
     Row(
         modifier = Modifier
             .fillMaxHeight()
             .fillMaxWidth()
-            .padding(top = (SEARCH_TEXT_FIELD_HEIGHT + SEARCH_TEXT_FIELD_TOP_PADDING + 8).dp, start = DEFAULT_MARGIN.dp),
+            .padding(
+                top = (SEARCH_TEXT_FIELD_HEIGHT + SEARCH_TEXT_FIELD_TOP_PADDING + 8).dp,
+                start = DEFAULT_MARGIN.dp
+            ),
         verticalAlignment = Alignment.Top
     ) {
+        val isKindClicked = filterViewModel.isKindFilterClicked.collectAsStateWithLifecycle()
+        val isGreatClicked = filterViewModel.isGreatFilterClicked.collectAsStateWithLifecycle()
+        val isSafeClicked = filterViewModel.isSafeFilterClicked.collectAsStateWithLifecycle()
         FilterButton(
             storeType = StoreType.KIND,
-            isKindFilterClicked,
-            onKindFilterChanged,
+            isKindClicked.value,
             mapViewModel,
             onFilterStateChanged
         )
         FilterButton(
             storeType = StoreType.GREAT,
-            isGreatFilterClicked,
-            onGreatFilterChanged,
+            isGreatClicked.value,
             mapViewModel,
             onFilterStateChanged
         )
         FilterButton(
             storeType = StoreType.SAFE,
-            isSafeFilterClicked,
-            onSafeFilterChanged,
+            isSafeClicked.value,
             mapViewModel,
             onFilterStateChanged
         )
@@ -84,16 +86,20 @@ fun FilterComponent(
 fun FilterButton(
     storeType: StoreType,
     isFilterClicked: Boolean,
-    onFilterChanged: (Boolean) -> Unit,
     mapViewModel: MapViewModel,
-    onFilterStateChanged: (Boolean) -> Unit
+    onFilterStateChanged: (Boolean) -> Unit,
+    filterViewModel: FilterViewModel = hiltViewModel(),
 ) {
     val certificationName = stringResource(id = storeType.storeTypeName).replace(" ", "")
     CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
         Button(
             onClick = {
                 mapViewModel.updateFilterSet(certificationName, isFilterClicked.not())
-                onFilterChanged(isFilterClicked.not())
+                when (storeType) {
+                    StoreType.KIND -> filterViewModel.updateKindFilterClicked()
+                    StoreType.SAFE -> filterViewModel.updateSafeFilterClicked()
+                    StoreType.GREAT -> filterViewModel.updateGreatFilterClicked()
+                }
                 onFilterStateChanged(true)
             },
             modifier = Modifier

--- a/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.presentation.ui.map.filter
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+
+@HiltViewModel
+class FilterViewModel @Inject constructor() : ViewModel() {
+
+    private val _isKindFilterClicked = MutableStateFlow(false)
+    val isKindFilterClicked: StateFlow<Boolean> get() = _isKindFilterClicked
+
+    private val _isGreatFilterClicked = MutableStateFlow(false)
+    val isGreatFilterClicked: StateFlow<Boolean> get() = _isGreatFilterClicked
+
+    private val _isSafeFilterClicked = MutableStateFlow(false)
+    val isSafeFilterClicked: StateFlow<Boolean> get() = _isSafeFilterClicked
+
+    fun updateKindFilterClicked() {
+        _isKindFilterClicked.value = _isKindFilterClicked.value.not()
+    }
+
+    fun updateGreatFilterClicked() {
+        _isGreatFilterClicked.value = _isGreatFilterClicked.value.not()
+    }
+
+    fun updateSafeFilterClicked() {
+        _isSafeFilterClicked.value = _isSafeFilterClicked.value.not()
+    }
+
+    fun updateAllFilterUnClicked() {
+        _isKindFilterClicked.value = false
+        _isGreatFilterClicked.value = false
+        _isSafeFilterClicked.value = false
+        Log.d("테스트","${_isKindFilterClicked.value}")
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/filter/FilterViewModel.kt
@@ -1,7 +1,7 @@
 package com.example.presentation.ui.map.filter
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.example.presentation.util.MainConstants
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,6 +11,11 @@ import javax.inject.Inject
 @HiltViewModel
 class FilterViewModel @Inject constructor() : ViewModel() {
 
+    private val _isFilteredMarker = MutableStateFlow(false)
+    val isFilteredMarker: StateFlow<Boolean> = _isFilteredMarker
+
+    private val filterSet = mutableSetOf<String>()
+
     private val _isKindFilterClicked = MutableStateFlow(false)
     val isKindFilterClicked: StateFlow<Boolean> get() = _isKindFilterClicked
 
@@ -19,6 +24,30 @@ class FilterViewModel @Inject constructor() : ViewModel() {
 
     private val _isSafeFilterClicked = MutableStateFlow(false)
     val isSafeFilterClicked: StateFlow<Boolean> get() = _isSafeFilterClicked
+
+    fun getFilterSet(): Set<String> {
+        return if (filterSet.isEmpty()) setOf(
+            MainConstants.SAFE_STORE,
+            MainConstants.GREAT_STORE,
+            MainConstants.KIND_STORE
+        )
+        else filterSet.toSet()
+    }
+
+    fun updateFilterSet(certificationName: String, isClicked: Boolean) {
+        if (isClicked) {
+            filterSet.add(certificationName)
+        } else {
+            filterSet.remove(certificationName)
+        }
+    }
+
+    fun updateAllFilterUnClicked() {
+        filterSet.clear()
+        _isKindFilterClicked.value = false
+        _isGreatFilterClicked.value = false
+        _isSafeFilterClicked.value = false
+    }
 
     fun updateKindFilterClicked() {
         _isKindFilterClicked.value = _isKindFilterClicked.value.not()
@@ -32,10 +61,7 @@ class FilterViewModel @Inject constructor() : ViewModel() {
         _isSafeFilterClicked.value = _isSafeFilterClicked.value.not()
     }
 
-    fun updateAllFilterUnClicked() {
-        _isKindFilterClicked.value = false
-        _isGreatFilterClicked.value = false
-        _isSafeFilterClicked.value = false
-        Log.d("테스트","${_isKindFilterClicked.value}")
+    fun updateIsFilteredMarker(isFilteredMarker: Boolean) {
+        _isFilteredMarker.value = isFilteredMarker
     }
 }

--- a/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/map/list/StoreListBottomSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.R
 import com.example.presentation.mapper.toUiModel
@@ -33,6 +34,7 @@ import com.example.presentation.model.StoreDetail
 import com.example.presentation.ui.component.BottomSheetDragHandle
 import com.example.presentation.ui.component.EmptyScreen
 import com.example.presentation.ui.map.MapViewModel
+import com.example.presentation.ui.map.filter.FilterViewModel
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.DarkGray
 import com.example.presentation.ui.theme.SemiLightGray
@@ -145,7 +147,8 @@ fun StoreListContent(
     onStoreInfoChanged: (StoreDetail) -> Unit,
     onMarkerChanged: (Long) -> Unit,
     onListItemChanged: (Boolean) -> Unit,
-    viewModel: MapViewModel
+    viewModel: MapViewModel,
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
     val storeDetailData by viewModel.flattenedStoreDetailList.collectAsStateWithLifecycle()
 
@@ -160,7 +163,7 @@ fun StoreListContent(
             LazyColumn {
                 itemsIndexed(
                     storeDetailData.filter {
-                        viewModel.getFilterSet().intersect(it.certificationName.toSet())
+                        filterViewModel.getFilterSet().intersect(it.certificationName.toSet())
                             .isNotEmpty()
                     }
                 ) { _, item ->

--- a/presentation/src/main/java/com/example/presentation/ui/search/ReSearchComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/ReSearchComponent.kt
@@ -25,9 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.presentation.R
-import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.map.reload.LoadingAnimation
 import com.example.presentation.ui.map.reload.setReloadButtonBottomPadding
 import com.example.presentation.ui.theme.Black
@@ -36,7 +34,7 @@ import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.UN_MARKER
 
 @Composable
-fun ReSearchComponent(
+fun ReSearchButtonComponent(
     isMarkerClicked: Boolean,
     currentSummaryInfoHeight: Dp,
     isMapGestured: Boolean,
@@ -76,7 +74,6 @@ fun ReSearchButton(
     onMarkerChanged: (Long) -> Unit,
     onBottomSheetChanged: (Boolean) -> Unit,
     isLoading: Boolean,
-    viewModel: MapViewModel = hiltViewModel()
 ) {
     Button(
         onClick = {

--- a/presentation/src/main/java/com/example/presentation/ui/search/ReSearchComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/ReSearchComponent.kt
@@ -1,0 +1,127 @@
+package com.example.presentation.ui.search
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.presentation.R
+import com.example.presentation.ui.map.MapViewModel
+import com.example.presentation.ui.map.reload.LoadingAnimation
+import com.example.presentation.ui.map.reload.setReloadButtonBottomPadding
+import com.example.presentation.ui.theme.Black
+import com.example.presentation.ui.theme.Blue
+import com.example.presentation.ui.theme.White
+import com.example.presentation.util.MainConstants.UN_MARKER
+
+@Composable
+fun ReSearchComponent(
+    isMarkerClicked: Boolean,
+    currentSummaryInfoHeight: Dp,
+    isMapGestured: Boolean,
+    onReSearchButtonChanged: (Boolean) -> Unit,
+    onMarkerChanged: (Long) -> Unit,
+    onBottomSheetChanged: (Boolean) -> Unit,
+    isLoading: Boolean,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .fillMaxWidth()
+            .padding(
+                bottom = setReloadButtonBottomPadding(
+                    isMarkerClicked,
+                    currentSummaryInfoHeight
+                )
+            ),
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (isMapGestured) {
+            ReSearchButton(
+                onReSearchButtonChanged,
+                onMarkerChanged,
+                onBottomSheetChanged,
+                isLoading,
+            )
+        }
+    }
+}
+
+
+@Composable
+fun ReSearchButton(
+    onReSearchButtonChanged: (Boolean) -> Unit,
+    onMarkerChanged: (Long) -> Unit,
+    onBottomSheetChanged: (Boolean) -> Unit,
+    isLoading: Boolean,
+    viewModel: MapViewModel = hiltViewModel()
+) {
+    Button(
+        onClick = {
+            onMarkerChanged(UN_MARKER)
+            onBottomSheetChanged(false)
+            onReSearchButtonChanged(true)
+        },
+        modifier = Modifier
+            .size(width = 145.dp, height = 35.dp),
+        contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = White,
+            contentColor = Black
+        ),
+        shape = RoundedCornerShape(30.dp),
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.align(Alignment.CenterVertically)
+        ) {
+            if (isLoading) {
+                LoadingAnimation()
+            } else {
+                ReSearchByKeyword()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReSearchByKeyword() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.reload),
+            tint = Blue,
+            contentDescription = "ReSearch",
+            modifier = Modifier.size(13.dp)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = stringResource(R.string.search_by_keyword_on_current_map),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -239,13 +239,16 @@ fun insertSearchWord(keyword: String, viewModel: SearchViewModel) {
 
 @Composable
 private fun BackArrow(navController: NavHostController, mapViewModel: MapViewModel) {
+    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
     Image(
         imageVector = ImageVector.vectorResource(id = R.drawable.arrow),
         contentDescription = "Arrow",
         modifier = Modifier
             .size(18.dp)
             .clickable {
-                mapViewModel.updateIsSearchTerminated(true)
+                if (mapScreenType == MapScreenType.MAIN) {
+                    mapViewModel.updateIsSearchTerminated(true)
+                }
                 navController.popBackStack()
             }
     )

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -198,12 +198,11 @@ fun SearchTextField(
         modifier = Modifier.focusRequester(focusRequester),
         keyboardActions = KeyboardActions(onDone = {
             filterViewModel.updateAllFilterUnClicked()
-            mapViewModel.initializeFilterSet()
 
             if (searchText.isNotBlank()) {
                 insertSearchWord(searchText, searchViewModel)
 
-                mapViewModel.updateIsFilteredMarker(false)
+                filterViewModel.updateIsFilteredMarker(false)
                 mapViewModel.searchStore(
                     mapCenterCoordinate.longitude,
                     mapCenterCoordinate.latitude,

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -84,7 +84,7 @@ fun SearchScreen(
     ) {
         SearchAppBar(navController, mapViewModel)
         SearchDivider(6)
-        RecentSearchList(onDeleteAllDialogVisibleChanged)
+        RecentSearchList(onDeleteAllDialogVisibleChanged, navController)
 
         if (isDeleteAllDialogVisible) {
             DeleteAllDialog(onDeleteAllDialogVisibleChanged)
@@ -257,10 +257,11 @@ private fun BackArrow(navController: NavHostController, mapViewModel: MapViewMod
 @Composable
 fun RecentSearchList(
     onDeleteAllDialogVisibleChanged: (Boolean) -> Unit,
-    viewModel: SearchViewModel = hiltViewModel()
+    navController: NavHostController,
+    searchViewModel: SearchViewModel = hiltViewModel()
 ) {
-    viewModel.getRecentSearchWord()
-    val recentSearchWords by viewModel.recentSearchWords.collectAsStateWithLifecycle()
+    searchViewModel.getRecentSearchWord()
+    val recentSearchWords by searchViewModel.recentSearchWords.collectAsStateWithLifecycle()
 
 
     TitleText(recentSearchWords, onDeleteAllDialogVisibleChanged)
@@ -270,7 +271,7 @@ fun RecentSearchList(
     } else {
         LazyColumn {
             itemsIndexed(recentSearchWords) { idx, item ->
-                RecentSearchItem(item)
+                RecentSearchItem(item, navController)
                 SearchDivider(1)
             }
         }
@@ -307,12 +308,37 @@ fun TitleText(exampleItems: List<SearchWord>, onDeleteAllDialogVisibleChanged: (
 }
 
 @Composable
-fun RecentSearchItem(searchWord: SearchWord, viewModel: SearchViewModel = hiltViewModel()) {
+fun RecentSearchItem(
+    searchWord: SearchWord,
+    navController: NavHostController,
+    mapViewModel: MapViewModel = hiltViewModel(),
+    searchViewModel: SearchViewModel = hiltViewModel(),
+    filterViewModel: FilterViewModel = hiltViewModel()
+) {
+    val mapCenterCoordinate by mapViewModel.mapCenterCoordinate.collectAsStateWithLifecycle()
+    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(53.dp)
-            .padding(horizontal = DEFAULT_MARGIN.dp),
+            .padding(horizontal = DEFAULT_MARGIN.dp)
+            .clickable {
+                // TODO : 최근 검색어 클릭 시 검색 구현
+                filterViewModel.updateAllFilterUnClicked()
+                insertSearchWord(searchWord.keyword, searchViewModel)
+
+                filterViewModel.updateIsFilteredMarker(false)
+                mapViewModel.searchStore(
+                    mapCenterCoordinate.longitude,
+                    mapCenterCoordinate.latitude,
+                    searchWord.keyword
+                )
+                navController.currentBackStackEntry?.savedStateHandle?.set(
+                    key = SEARCH_KEY,
+                    value = searchWord.keyword
+                )
+                mapViewModel.updateMapScreenType(MapScreenType.SEARCH)
+            },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
@@ -343,7 +369,7 @@ fun RecentSearchItem(searchWord: SearchWord, viewModel: SearchViewModel = hiltVi
             modifier = Modifier
                 .size(16.dp)
                 .clickable {
-                    viewModel.deleteSearchWordById(searchWord.id)
+                    searchViewModel.deleteSearchWordById(searchWord.id)
                 }
         )
     }

--- a/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/SearchScreen.kt
@@ -54,6 +54,7 @@ import com.example.domain.model.search.SearchWord
 import com.example.presentation.R
 import com.example.presentation.ui.component.EmptyScreen
 import com.example.presentation.ui.map.MapViewModel
+import com.example.presentation.ui.map.filter.FilterViewModel
 import com.example.presentation.ui.navigation.Screen
 import com.example.presentation.ui.theme.Black
 import com.example.presentation.ui.theme.DarkGray
@@ -132,6 +133,7 @@ fun SearchTextField(
     navController: NavHostController,
     mapViewModel: MapViewModel,
     searchViewModel: SearchViewModel = hiltViewModel(),
+    filterViewModel: FilterViewModel = hiltViewModel()
 ) {
     var searchText by remember { mutableStateOf("") }
 
@@ -195,6 +197,9 @@ fun SearchTextField(
         textStyle = TextStyle(color = Black, fontSize = 14.sp, fontWeight = Medium),
         modifier = Modifier.focusRequester(focusRequester),
         keyboardActions = KeyboardActions(onDone = {
+            filterViewModel.updateAllFilterUnClicked()
+            mapViewModel.initializeFilterSet()
+
             if (searchText.isNotBlank()) {
                 insertSearchWord(searchText, searchViewModel)
 

--- a/presentation/src/main/java/com/example/presentation/ui/search/StoreSearchComponent.kt
+++ b/presentation/src/main/java/com/example/presentation/ui/search/StoreSearchComponent.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -26,19 +27,25 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.presentation.R
+import com.example.presentation.ui.map.MapViewModel
 import com.example.presentation.ui.theme.MediumGray
 import com.example.presentation.ui.theme.White
 import com.example.presentation.util.MainConstants.DEFAULT_MARGIN
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_HEIGHT
 import com.example.presentation.util.MainConstants.SEARCH_TEXT_FIELD_TOP_PADDING
+import com.example.presentation.util.MapScreenType
 
 @Composable
 fun StoreSearchComponent(
     searchText: String?,
     onSearchComponentChanged: (Boolean) -> Unit,
-    onSearchTerminationButtonChanged: (Boolean) -> Unit
+    onSearchTerminationButtonChanged: (Boolean) -> Unit,
+    mapViewModel: MapViewModel
 ) {
+    val mapScreenType by mapViewModel.mapScreenType.collectAsStateWithLifecycle()
+
     Row(
         modifier = Modifier
             .padding(
@@ -61,11 +68,11 @@ fun StoreSearchComponent(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        if (searchText.isNullOrBlank()) {
+        if (mapScreenType == MapScreenType.MAIN) {
             SearchPlaceHolderText(stringResource(R.string.search_placeholder_text), MediumGray)
             SearchSuffixImage(R.drawable.search)
         } else {
-            SearchPlaceHolderText(searchText, Black)
+            SearchPlaceHolderText(searchText ?: "", Black)
             SearchSuffixImage(
                 R.drawable.delete,
                 onSearchTerminationButtonChanged

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="copy_to_clipboard_description">클립보드에 복사되었어요.</string>
     <string name="tel">tel:%s</string>
     <string name="search_on_current_map">현 지도에서 검색</string>
+    <string name="search_by_keyword_on_current_map">현재 키워드로 재검색</string>
     <string name="operating">영업 중</string>
     <string name="closed">영업 종료</string>
     <string name="day_off">휴무일</string>


### PR DESCRIPTION
## ⭐️ Issue Number

- #82 

## 🚩 Summary

앱 터지는 문제 해결!!
원인 : BasicTextField에서 innerTextField는 한 번만 호출되어야하는데, if문 안에서 여러번 호출될 때마다 앱이 터졌던 것

## 🛠️ Technical Concerns

최근 검색어 리스트 클릭 시, 해당 키워드에 대해 검색을 진행하고 지도로 이동한 뒤 결과를 띄워주는 과정이 SearchScreen의 BasicTextField에서 keyboardActions가 onDone일 때의 로직과 같다고 판단해 같은 코드를 넣어주었습니다. (if (searchText.isNotBlank()) 부분 제외)

그런데 마커와 바텀시트에 검색 결과 데이터가 아닌, 가게 상세정보 데이터가 노출되는 버그가 발생했습니다.
NaverMapScreen에서 `if (mapScreenType == MapScreenType.MAIN)`쪽으로 넘어가서 생기는 문제인 것 같은데 RecentSearchItem내부에서 MapScreenType.SEARCH로 업데이트 해줬는데도 이런 문제가 발생하는 원인이 뭘까요?ㅜㅜ

## 🙂 To Reviwer

## 📋 To Do
